### PR TITLE
Updated CLI init command to be inline with spec

### DIFF
--- a/change/@microsoft-cfp-template-da197de9-6c13-49b5-b314-3ec1ec6131bc.json
+++ b/change/@microsoft-cfp-template-da197de9-6c13-49b5-b314-3ec1ec6131bc.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Updated CLI init command to be inline with spec",
+  "packageName": "@microsoft/cfp-template",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@microsoft-fast-cli-53dcd150-6f3e-42b8-a69b-b6f9c7a8c18b.json
+++ b/change/@microsoft-fast-cli-53dcd150-6f3e-42b8-a69b-b6f9c7a8c18b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Updated CLI init command to be inline with spec",
+  "packageName": "@microsoft/fast-cli",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/cfp-template/template/README.md
+++ b/packages/cfp-template/template/README.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Welcome to the default starter template provided by the FAST CLI.
+Welcome to the default starter template provided by the [FAST CLI](https://microsoft.github.io/fast-cli).
 
 This template can be used as a starting point for your project.
 

--- a/packages/cfp-template/template/fastinit.json
+++ b/packages/cfp-template/template/fastinit.json
@@ -1,5 +1,16 @@
 {
+    "fastConfig": {
+        "componentPath": "./src/components"
+    },
     "packageJson": {
+        "name": "fast-project",
+        "description": "A FAST project",
+        "private": true,
+        "type": "module",
+        "version": "0.1.0",
+        "author": "",
+        "license": "ISC",
+        "repository": "",
         "scripts": {
             "build": "webpack --config=./webpack.prod.cjs",
             "eslint": "eslint . --ext .ts",

--- a/packages/fast-cli/README.md
+++ b/packages/fast-cli/README.md
@@ -14,12 +14,4 @@
 
 ## Usage
 
-### Init
-
-local/global install - `fast init`
-npx - `npx @microsoft/fast-cli init`
-
-Argument | Shorthand | Description | Required
----------|-----------|-------------|---------
-`--defaults` | `-d` | Use defaults | No
-`--template <path/to/template>` | `-t <path/to/template>` | Use a local template | No
+Check out our documentation for details at https://microsoft.github.io/fast-cli/.

--- a/packages/fast-cli/src/cli.options.ts
+++ b/packages/fast-cli/src/cli.options.ts
@@ -1,13 +1,8 @@
-#!/usr/bin/env node
+export interface FastConfig {
+    componentPath: string;
+}
 
-/* eslint-disable no-useless-escape */
-const folderMatches = process.cwd().match(/[^(\\|\/)]+(?=$)/);
-const projectName: string = folderMatches !== null ? folderMatches[0] : "new-project";
-
-/**
- * Configuration options for the package.json file
- */
-export interface PackageJsonConfig {
+export interface PackageJson {
     name: string;
     version: string;
     description: string;
@@ -17,15 +12,7 @@ export interface PackageJsonConfig {
     license: string;
 }
 
-/**
- * Default config
- */
-export const defaultPackageJsonConfig: PackageJsonConfig = {
-    name: projectName,
-    version: "0.1.0",
-    description: "",
-    repository: "",
-    keywords: "",
-    author: "",
-    license: "ISC",
+export interface FastInit {
+    fastConfig: FastConfig,
+    packageJson: PackageJson
 }

--- a/packages/fast-cli/src/cli.spec.ts
+++ b/packages/fast-cli/src/cli.spec.ts
@@ -33,7 +33,7 @@ test.describe.skip("CLI", () => {
             const packageJsonString = fs.readFileSync(path.resolve(tempDir, "package.json"), { "encoding": "utf8" });
             const packageJson = JSON.parse(packageJsonString);
             packageJson.scripts = {
-                fastinit: `fast init -d -t ${path.resolve(dirname, "../cfp-template")}`
+                fastinit: `fast init -t ${path.resolve(dirname, "../cfp-template")}`
             }
             fs.writeFileSync(path.resolve(tempDir, "package.json"), JSON.stringify(packageJson, null, 2));
             execSync(`cd ${tempDir} && npm run fastinit`);
@@ -41,20 +41,40 @@ test.describe.skip("CLI", () => {
         test.afterAll(() => {
             fs.removeSync(tempDir);
         });
-        test("should create a package.json file with default contents", () => {
+        test("should create a package.json file with contents from the fast init", () => {
             const packageJsonFile = JSON.parse(
                 fs.readFileSync(path.resolve(tempDir, "package.json"), {
                     encoding: "utf8",
                 })
             );
             const configFilePackageJson = JSON.parse(
-                fs.readFileSync(path.resolve(tempDir, "fastconfig.json"), {
+                fs.readFileSync(path.resolve(tempDir, "fastinit.json"), {
                     encoding: "utf8",
                 })
             ).packageJson;
     
             for (const [key, value] of Object.entries(configFilePackageJson)) {
-                expect(packageJsonFile[key].toString()).toEqual((value as any).toString());
+                if (key !== "name") {
+                    expect(packageJsonFile[key].toString()).toEqual((value as any).toString());
+                } else {
+                    expect(packageJsonFile[key].toString()).toEqual("temp");
+                }
+            }
+        });
+        test("should create a fastconfig file with contents from the fast init", () => {
+            const fastConfigFile = JSON.parse(
+                fs.readFileSync(path.resolve(tempDir, "fastconfig.json"), {
+                    encoding: "utf8",
+                })
+            );
+            const configFilePackageJson = JSON.parse(
+                fs.readFileSync(path.resolve(tempDir, "fastinit.json"), {
+                    encoding: "utf8",
+                })
+            ).fastConfig;
+    
+            for (const [key, value] of Object.entries(configFilePackageJson)) {
+                expect(fastConfigFile[key].toString()).toEqual((value as any).toString());
             }
         });
         test("should copy the template folder contents", () =>{

--- a/packages/fast-cli/src/cli.ts
+++ b/packages/fast-cli/src/cli.ts
@@ -6,12 +6,14 @@ import * as commander from "commander";
 import prompts from "prompts";
 import spawn from "cross-spawn";
 import fs from "fs-extra";
-import { defaultPackageJsonConfig, PackageJsonConfig } from "./cli.options.js";
+import type { FastConfig, FastInit, PackageJson } from "./cli.options";
 
 const __dirname = path.resolve(path.dirname(""));
 const program = new commander.Command();
 const defaultTemplatePath = path.resolve(__dirname, "@microsoft/cfp-template");
 const defaultTemplateFolderName = "template";
+/* eslint-disable no-useless-escape */
+const folderMatches = process.cwd().match(/[^(\\|\/)]+(?=$)/);
 const ascii = `
 
   ███████╗ █████╗ ███████╗████████╗     ██████╗██╗     ██╗
@@ -64,13 +66,37 @@ function checkNpmRegistryIsAvailable(): Promise<boolean | unknown> {
 }
 
 /**
+ * Get the fastinit.json file
+ */
+function getFastInitFile(
+    pathToTemplatePackage: string
+): Promise<FastInit> {
+    return new Promise<FastInit>((resolve, reject) => {
+        const templateDir = path.resolve(
+            __dirname,
+            "node_modules",
+            pathToTemplatePackage,
+            defaultTemplateFolderName
+        );
+
+        resolve(JSON.parse(
+            fs.readFileSync(path.resolve(templateDir, "fastinit.json"), {
+                encoding: "utf8",
+            })
+        ) as FastInit);
+    }).catch((reason) => {
+        throw reason;
+    });
+}
+
+/**
  * Copy the template to the project
  */
 function copyTemplateToProject(
-    packageJson: PackageJsonConfig,
-    pathToTemplatePackage: string
-): Promise<unknown> {
-    return new Promise((resolve, reject) => {
+    pathToTemplatePackage: string,
+    packageJson: PackageJson,
+): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
         const templateDir = path.resolve(
             __dirname,
             "node_modules",
@@ -93,32 +119,15 @@ function copyTemplateToProject(
             }
         );
 
-        // Update the package.json with the user response
-        const templateConfigPackageJsonFileContents = JSON.parse(
-            fs.readFileSync(path.resolve(templateDir, "fastconfig.json"), {
-                encoding: "utf8",
-            })
-        ).packageJson;
-        const packageJsonFileContents: { [key: string]: any } = packageJson;
-        packageJsonFileContents["repository"] = {
-            type: "git",
-            url: packageJson["repository"],
-        };
-        [
-            "dependencies",
-            "devDependencies",
-            "peerDependencies",
-            "scripts",
-            "main",
-        ].forEach(property => {
-            packageJsonFileContents[property] = templateConfigPackageJsonFileContents[property];
-        });
-
-        fs.writeJsonSync(path.resolve(destDir, "package.json"), packageJsonFileContents, {
+        const packageName = folderMatches !== null ? folderMatches[0] : packageJson.name;
+        fs.writeJsonSync(path.resolve(destDir, "package.json"), {
+            ...packageJson,
+            name: packageName
+        }, {
             spaces: 2,
         });
 
-        resolve(void 0);
+        resolve(packageName);
     }).catch((reason) => {
         throw reason;
     });
@@ -190,14 +199,30 @@ function installTemplate(pathToTemplate: string): Promise<unknown> {
     });
 }
 
+function createConfigFile(
+    fastConfig: FastConfig,
+): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+        fs.writeJsonSync(path.resolve(process.cwd(), "fastconfig.json"), {
+            ...fastConfig
+        }, {
+            spaces: 2,
+        });
+
+        resolve();
+    }).catch((reason) => {
+        throw reason;
+    });
+}
+
 /**
  * Uninstall a package holding a template
  */
-function uninstallTemplate(packageJson: PackageJsonConfig,): Promise<unknown> {
+function uninstallTemplate(packageName: string): Promise<unknown> {
     return new Promise((resolve, reject) => {
         const args = [
             "uninstall",
-            packageJson.name,
+            packageName,
         ];
         const child = spawn("npm", args, { stdio: "inherit" });
         child.on("close", code => {
@@ -218,8 +243,7 @@ function uninstallTemplate(packageJson: PackageJsonConfig,): Promise<unknown> {
  * Initialize a FAST project
  */
 async function init(options: InitOptions): Promise<void> {
-    let packageJson = defaultPackageJsonConfig;
-    let pathToTemplatePackage;
+    let pathToTemplatePackage = options.template;
 
     if (options.template) {
         pathToTemplatePackage = path.resolve(__dirname, options.template);
@@ -231,63 +255,32 @@ async function init(options: InitOptions): Promise<void> {
         }
     }
 
-    if (!options.defaults) {
+    if (!options.template) {
         /**
          * Collect information for the package.json file
          */
-        packageJson = await prompts([
+         pathToTemplatePackage = await prompts([
             {
                 type: "text",
-                name: "name",
-                initial: defaultPackageJsonConfig.name,
-                message: "project name",
-            },
-            {
-                type: "text",
-                name: "version",
-                initial: defaultPackageJsonConfig.version,
-                message: "version",
-            },
-            {
-                type: "text",
-                name: "description",
-                message: "description",
-            },
-            {
-                type: "text",
-                name: "repository",
-                message: "git repository",
-            },
-            {
-                type: "text",
-                name: "keywords",
-                message: "keywords",
-            },
-            {
-                type: "text",
-                name: "author",
-                message: "author",
-            },
-            {
-                type: "text",
-                name: "license",
-                initial: defaultPackageJsonConfig.license,
-                message: "license",
-            },
-        ]);
+                name: "template",
+                initial: defaultTemplatePath,
+                message: "Template path or package name",
+            }
+        ]).template;
     }
 
+    const initFile: FastInit = await getFastInitFile(pathToTemplatePackage);
     await installTemplate(pathToTemplatePackage);
-    await copyTemplateToProject(packageJson, pathToTemplatePackage);
+    await createConfigFile(initFile.fastConfig);
+    const packageName: string = await copyTemplateToProject(pathToTemplatePackage, initFile.packageJson);
     await installDependencies();
     await installPlaywrightBrowsers();
-    await uninstallTemplate(packageJson);
+    await uninstallTemplate(packageName);
 }
 
 program
     .command("init")
     .description("Initialize a new project")
-    .option("-d, --defaults", "Use defaults")
     .option("-t, --template <template>", "Path to project template")
     .action(async (options): Promise<void> => {
         await init(options).catch((reason) => {

--- a/packages/fast-cli/src/cli.ts
+++ b/packages/fast-cli/src/cli.ts
@@ -70,23 +70,19 @@ function checkNpmRegistryIsAvailable(): Promise<boolean | unknown> {
  */
 function getFastInitFile(
     pathToTemplatePackage: string
-): Promise<FastInit> {
-    return new Promise<FastInit>((resolve, reject) => {
-        const templateDir = path.resolve(
-            __dirname,
-            "node_modules",
-            pathToTemplatePackage,
-            defaultTemplateFolderName
-        );
+): FastInit {
+    const templateDir = path.resolve(
+        __dirname,
+        "node_modules",
+        pathToTemplatePackage,
+        defaultTemplateFolderName
+    );
 
-        resolve(JSON.parse(
-            fs.readFileSync(path.resolve(templateDir, "fastinit.json"), {
-                encoding: "utf8",
-            })
-        ) as FastInit);
-    }).catch((reason) => {
-        throw reason;
-    });
+    return JSON.parse(
+        fs.readFileSync(path.resolve(templateDir, "fastinit.json"), {
+            encoding: "utf8",
+        })
+    );
 }
 
 /**
@@ -95,42 +91,38 @@ function getFastInitFile(
 function copyTemplateToProject(
     pathToTemplatePackage: string,
     packageJson: PackageJson,
-): Promise<string> {
-    return new Promise<string>((resolve, reject) => {
-        const templateDir = path.resolve(
-            __dirname,
-            "node_modules",
-            pathToTemplatePackage,
-            defaultTemplateFolderName
-        );
-        const destDir = path.resolve(__dirname);
+): string {
+    const templateDir = path.resolve(
+        __dirname,
+        "node_modules",
+        pathToTemplatePackage,
+        defaultTemplateFolderName
+    );
+    const destDir = path.resolve(__dirname);
 
-        // Copy all files in the template folder
-        fs.copySync(
-            templateDir,
-            destDir,
-            {
-                overwrite: true,
-            },
-            (error: string) => {
-                if (error) {
-                    throw new Error(error);
-                }
+    // Copy all files in the template folder
+    fs.copySync(
+        templateDir,
+        destDir,
+        {
+            overwrite: true,
+        },
+        (error: string) => {
+            if (error) {
+                throw new Error(error);
             }
-        );
+        }
+    );
 
-        const packageName = folderMatches !== null ? folderMatches[0] : packageJson.name;
-        fs.writeJsonSync(path.resolve(destDir, "package.json"), {
-            ...packageJson,
-            name: packageName
-        }, {
-            spaces: 2,
-        });
-
-        resolve(packageName);
-    }).catch((reason) => {
-        throw reason;
+    const packageName = folderMatches !== null ? folderMatches[0] : packageJson.name;
+    fs.writeJsonSync(path.resolve(destDir, "package.json"), {
+        ...packageJson,
+        name: packageName
+    }, {
+        spaces: 2,
     });
+
+    return packageName;
 }
 
 /**
@@ -201,17 +193,11 @@ function installTemplate(pathToTemplate: string): Promise<unknown> {
 
 function createConfigFile(
     fastConfig: FastConfig,
-): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
-        fs.writeJsonSync(path.resolve(process.cwd(), "fastconfig.json"), {
-            ...fastConfig
-        }, {
-            spaces: 2,
-        });
-
-        resolve();
-    }).catch((reason) => {
-        throw reason;
+): void {
+    fs.writeJsonSync(path.resolve(process.cwd(), "fastconfig.json"), {
+        ...fastConfig
+    }, {
+        spaces: 2,
     });
 }
 
@@ -269,10 +255,10 @@ async function init(options: InitOptions): Promise<void> {
         ]).template;
     }
 
-    const initFile: FastInit = await getFastInitFile(pathToTemplatePackage);
+    const initFile: FastInit = getFastInitFile(pathToTemplatePackage);
     await installTemplate(pathToTemplatePackage);
-    await createConfigFile(initFile.fastConfig);
-    const packageName: string = await copyTemplateToProject(pathToTemplatePackage, initFile.packageJson);
+    createConfigFile(initFile.fastConfig);
+    const packageName: string = copyTemplateToProject(pathToTemplatePackage, initFile.packageJson);
     await installDependencies();
     await installPlaywrightBrowsers();
     await uninstallTemplate(packageName);

--- a/specs/fast-cli.md
+++ b/specs/fast-cli.md
@@ -77,7 +77,7 @@ Argument | Shorthand | Description | Required | Default |
 
 ```json
 {
-    "component-path": "./src/components"
+    "componentPath": "./src/components"
 }
 ```
 
@@ -105,7 +105,7 @@ export const designSystem = {
 };
 ```
 
-> Important: A fastconfig.json must exist with the "component-path" property set. If it does not, the user should be prompted to run the `fast config` command.
+> Important: A fastconfig.json must exist with the "componentPath" property set. If it does not, the user should be prompted to run the `fast config` command.
 
 ## Add a component
 
@@ -128,6 +128,8 @@ Should no template or foundation component be selected, a blank component will b
 TBD list available foundation components.
 
 > Important: The user should be prompted if no design system is present when attempting to add a new component to run the command `fast add-design-system`.
+
+> Important: During implementation the `define.ts` which will be part of a components template may require a `package.json` update to include a list of `sideEffects`.
 
 ## Templates
 

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -23,5 +23,4 @@ npx - `npx @microsoft/fast-cli init`
 
 Argument | Shorthand | Description | Required
 ---------|-----------|-------------|---------
-`--defaults` | `-d` | Use defaults | No
 `--template <path/to/template>` | `-t <path/to/template>` | Use a local template | No


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This change updates the FAST CLI current API to be inline with the new [specification](https://github.com/microsoft/fast-cli/blob/main/specs/fast-cli.md#initializing) where all "defaults" originate from the template and the template is the only option.

Other changes:
- Redirect consumers to the FAST CLI docs site in the README.md files
- Update the spec file to use camelCase

### 🎫 Issues

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->
Closes #26

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
- #27