### PR TITLE
Users/janechu/add configuration command

### DIFF
--- a/change/@microsoft-fast-cli-44f49680-f85c-484a-a6a9-b0cb934573c9.json
+++ b/change/@microsoft-fast-cli-44f49680-f85c-484a-a6a9-b0cb934573c9.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added configuration command and cleaned up init",
+  "packageName": "@microsoft/fast-cli",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/specs/fast-cli.md
+++ b/specs/fast-cli.md
@@ -71,7 +71,7 @@ $ fast config
 
 Argument | Shorthand | Description | Required | Default |
 ---------|-----------|-------------|----------|---------|
-`--component-path` | `-p` | The relative path of the FAST components folder | Yes | |
+`--component-path <path/to/components>` | `-p <path/to/components>` | The relative path of the FAST components folder | Yes | |
 
 ### Example fastconfig.json file
 

--- a/website/docs/configure.md
+++ b/website/docs/configure.md
@@ -1,0 +1,23 @@
+# Configure
+
+Running the `config` command will create a `fastconfig.json` file. This should be useful in existing projects which could take advantage of the CLI once it has been initialized.
+
+```bash
+$ fast config
+```
+
+### Arguments
+
+Argument | Shorthand | Description | Required | Default |
+---------|-----------|-------------|----------|---------|
+`--component-path <path/to/components>` | `-p <path/to/components>` | The relative path of the FAST components folder | Yes | |
+
+### Example fastconfig.json file
+
+```json
+{
+    "componentPath": "./src/components"
+}
+```
+
+> Important: The paths of components and design system must be relative to each other, therefore only the path to the component folder is required as the design system file path is assumed. In an app the path may be `"./src/components"` as shown above, or in the case of a component library the path may be `"./src"`.

--- a/website/docs/initialize.md
+++ b/website/docs/initialize.md
@@ -14,7 +14,14 @@ Creating a new FAST project can be done easily, either using the `@microsoft/fas
 
 ## Creating a project using the CLI
 
+Install the `@microsoft/fast-cli` locally or globally.
+
 ```bash
-npm install -g @microsoft/fast-cli
-fast init
+$ fast init
 ```
+
+### Arguments
+
+Argument | Shorthand | Description | Required
+---------|-----------|-------------|---------
+`--template <path/to/template>` | `-t <path/to/template>` | Use a local template | No

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -13,14 +13,3 @@ Welcome to FAST CLI, a creation and workflow tool for your FAST project.
 > Tip
 >
 > Note that this is not a recommended practice, as this could cause issues if you have multiple projects which may need different versions. Instead use the local installation above and alias the commands into your project's `package.json` scripts.
-
-## Usage
-
-### Init
-
-local/global install - `fast init`
-npx - `npx @microsoft/fast-cli init`
-
-Argument | Shorthand | Description | Required
----------|-----------|-------------|---------
-`--template <path/to/template>` | `-t <path/to/template>` | Use a local template | No

--- a/website/docs/sidebar.js
+++ b/website/docs/sidebar.js
@@ -37,5 +37,10 @@ export default {
             label: "Initialize",
             path: "initialize",
         },
+        {
+            type: "doc",
+            label: "Configure",
+            path: "configure"
+        }
     ],
 };


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This change adds the `config` command which creates a config file with a component path. It also cleans up some of the `init` logic where template files provided in the command line were assumed to be local packages.

### 🎫 Issues

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->

Closes #27 

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
- #28