### PR TITLE
Updated the specification around adding foundation components

### DIFF
--- a/change/@microsoft-fast-cli-c795961d-2d44-4c34-84ef-bca98c594851.json
+++ b/change/@microsoft-fast-cli-c795961d-2d44-4c34-84ef-bca98c594851.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Updated the specification around adding foundation components",
+  "packageName": "@microsoft/fast-cli",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-cli/src/components/blank/README.md
+++ b/packages/fast-cli/src/components/blank/README.md
@@ -1,0 +1,3 @@
+# Description
+
+This template is used as an empty default from which a user can construct their own component without having to do the initial scaffolding.

--- a/specs/fast-cli.md
+++ b/specs/fast-cli.md
@@ -38,6 +38,7 @@ There are some issues with scaffolding projects outlined below:
 - [fast config](#configuration)
 - [fast add-design-system](#add-a-design-system)
 - [fast add-component](#add-a-component)
+- [fast add-foundation-component](#add-a-foundation-component)
 
 ## CLI information
 
@@ -69,9 +70,9 @@ $ fast config
 
 ### Arguments
 
-Argument | Shorthand | Description | Required | Default |
----------|-----------|-------------|----------|---------|
-`--component-path <path/to/components>` | `-p <path/to/components>` | The relative path of the FAST components folder | Yes | |
+Argument | Shorthand | Description | Required |
+---------|-----------|-------------|----------|
+`--component-path <path/to/components>` | `-p <path/to/components>` | The relative path of the FAST components folder | Yes |
 
 ### Example fastconfig.json file
 
@@ -109,7 +110,7 @@ export const designSystem = {
 
 ## Add a component
 
-Components are added and configured based on a design system.
+Components are added and configured based on a design system. Templates can use either the "blank" template with the default files, or it can point to a local or remote package.
 
 ```bash
 $ fast add-component
@@ -117,19 +118,26 @@ $ fast add-component
 
 ### Arguments
 
-Argument | Shorthand | Description | Required | Default
----------|-----------|-------------|----------|--------
+Argument | Shorthand | Description | Required | Options
+---------|-----------|-------------|----------|---------
 `--name <name>` | `-n <name>` | The name of the functionality to be added | Yes | |
-`--template <path/to/template>` | `-t <path/to/template>` | Template including HTML, CSS, and [other files](#component-templates) | No |
-`--foundation <foundation-component>` | `-f <foundation-component>` | Foundation template | No | 
-
-Should no template or foundation component be selected, a blank component will be created.
-
-TBD list available foundation components.
+`--template <path/to/template>` | `-t <path/to/template>` | Template including HTML, CSS, and [other files](#component-templates) | No | `<path/to/template>`, "blank" |
 
 > Important: The user should be prompted if no design system is present when attempting to add a new component to run the command `fast add-design-system`.
 
 > Important: During implementation the `define.ts` which will be part of a components template may require a `package.json` update to include a list of `sideEffects`.
+
+## Add a foundation component
+
+Components are added and configured based on a design system and rely on a `@microsoft/fast-foundation` depenency.
+
+```bash
+$ fast add-foundation-component
+```
+
+Argument | Shorthand | Description | Required | Default
+---------|-----------|-------------|----------|--------
+`--name <name>` | `-n <name>` | The name of the foundation element | Yes | "accordion", "accordion-item", "anchor", "anchored-region", "avatar", "badge", "breadcrumb", "breadcrumb-item", "button", "calendar", "card", "checkbox", "combobox", "data-grid", "dialog", "disclosure", "divider", "flipper", "horizontal-scroll", "listbox", "listbox-option", "menu", "menu-item", "number-field", "picker", "progress", "progress-ring", "radio", "radio-group", "search", "select", "skeleton", "slider", "slider-label", "switch", "tabs", "tab", "tab-panel", "text-area", "text-field", "toolbar", "tooltip", "tree-view", "tree-item" |
 
 ## Templates
 

--- a/specs/fast-cli.md
+++ b/specs/fast-cli.md
@@ -137,7 +137,8 @@ $ fast add-foundation-component
 
 Argument | Shorthand | Description | Required | Default
 ---------|-----------|-------------|----------|--------
-`--name <name>` | `-n <name>` | The name of the foundation element | Yes | "accordion", "accordion-item", "anchor", "anchored-region", "avatar", "badge", "breadcrumb", "breadcrumb-item", "button", "calendar", "card", "checkbox", "combobox", "data-grid", "dialog", "disclosure", "divider", "flipper", "horizontal-scroll", "listbox", "listbox-option", "menu", "menu-item", "number-field", "picker", "progress", "progress-ring", "radio", "radio-group", "search", "select", "skeleton", "slider", "slider-label", "switch", "tabs", "tab", "tab-panel", "text-area", "text-field", "toolbar", "tooltip", "tree-view", "tree-item" |
+`--template <template>` | `-t <template>` | The name of the foundation element | Yes | "accordion", "anchor", "anchored-region", "avatar", "badge", "breadcrumb", "button", "calendar", "card", "checkbox", "combobox", "data-grid", "dialog", "disclosure", "divider", "flipper", "horizontal-scroll", "listbox", "menu", "number-field", "picker", "progress", "progress-ring", "radio-group", "search", "select", "skeleton", "slider", "switch", "tabs", "text-area", "text-field", "toolbar", "tooltip", "tree-view" |
+`--name <name>` | `-n <name>` | The name of the component to be added | Yes | The name of the foundation template |
 
 ## Templates
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This update to the specification clarifies adding a "foundation" component with a specific `add-foundation-component` command.

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.
-->
Read through and make sure this command makes sense given the `add-component` command. Since the `add-component` command deals with adding via templates, the `add-foundation-component` is intended to explicit to adding foundation based component. This distinction was thought to be necessary as this adds the `@microsoft/fast-foundation` dependency and begins to use the preconfigured design tokens, so if you are not intending to use those systems, you would simply use the `add-component` command for your custom components.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
- #31