### PR TITLE
Add the add-foundation-component prompt

### DIFF
--- a/change/@microsoft-fast-cli-fa362d05-4957-47f3-9594-f7e1a31f45e1.json
+++ b/change/@microsoft-fast-cli-fa362d05-4957-47f3-9594-f7e1a31f45e1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added the add-foundation-component command",
+  "packageName": "@microsoft/fast-cli",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-cli/src/cli.options.ts
+++ b/packages/fast-cli/src/cli.options.ts
@@ -54,3 +54,13 @@ export interface AddComponentOptionMessages {
     name: string;
     template: string;
 }
+
+export interface AddFoundationComponentOptions {
+    name?: string;
+    template?: string;
+}
+
+export interface AddFoundationComponentOptionMessages {
+    name: string;
+    template: string;
+}

--- a/packages/fast-cli/src/cli.spec.ts
+++ b/packages/fast-cli/src/cli.spec.ts
@@ -58,8 +58,8 @@ function setup() {
         "fast:init": `fast init -t ${path.resolve(dirname, "../cfp-template")}`,
         "fast:config": `fast config -p ./src/components`,
         "fast:add-design-system": `fast add-design-system -p test -s open`,
-        "fast:add-component:blank": `fast add-component -n test-component -t blank`,
-        "fast:add-component:template": `fast add-component -n test-component -t ${path.resolve(dirname, "../temp-component")}`
+        "fast:add-component:template": `fast add-component -n test-component -t ${path.resolve(dirname, "../temp-component")}`,
+        "fast:add-foundation-component:blank": `fast add-foundation-component -n test-component -t blank`,
     };
     fs.writeFileSync(path.resolve(tempDir, "package.json"), JSON.stringify(packageJson, null, 2));
 }
@@ -204,56 +204,56 @@ test.describe("CLI", () => {
         });
     });
     test.describe("add-component", () => {
-        test.describe("template", () => {
-            test.beforeAll(() => {
-                setup();
-                execSync(`cd ${tempDir} && npm run fast:init`);
-                setup();
-                setupBlankAsTemplate();
-                execSync(`cd ${tempDir} && npm run fast:add-component:template`);
-            });
-            test.afterAll(() => {
-                teardown();
-            });
-            test("should copy files from a provided template", () => {
-                let files: Array<string> = [];
+        test.beforeAll(() => {
+            setup();
+            execSync(`cd ${tempDir} && npm run fast:init`);
+            setup();
+            setupBlankAsTemplate();
+            execSync(`cd ${tempDir} && npm run fast:add-component:template`);
+        });
+        test.afterAll(() => {
+            teardown();
+        });
+        test("should copy files from a provided template", () => {
+            let files: Array<string> = [];
 
-                function testGeneratedFiles(folderName: string) {
-                    const tempDirContents = fs.readdirSync(path.resolve(tempDir, "src/components/test-component", folderName));
-                    const tempDirContentsWithFileTypes = fs.readdirSync(path.resolve(tempDir, "src/components/test-component", folderName), {
-                        withFileTypes: true
-                    });
+            function testGeneratedFiles(folderName: string) {
+                const tempDirContents = fs.readdirSync(path.resolve(tempDir, "src/components/test-component", folderName));
+                const tempDirContentsWithFileTypes = fs.readdirSync(path.resolve(tempDir, "src/components/test-component", folderName), {
+                    withFileTypes: true
+                });
 
-                    for (let i = 0, contentLength = tempDirContents.length; i < contentLength; i++) {
-                        if (tempDirContentsWithFileTypes[i].isDirectory()) {
-                            testGeneratedFiles(tempDirContents[i]);
-                        } else {
-                            files.push(
-                                folderName
-                                    ? `${folderName}/${tempDirContents[i]}`
-                                    : tempDirContents[i]
-                            );
-                        }
+                for (let i = 0, contentLength = tempDirContents.length; i < contentLength; i++) {
+                    if (tempDirContentsWithFileTypes[i].isDirectory()) {
+                        testGeneratedFiles(tempDirContents[i]);
+                    } else {
+                        files.push(
+                            folderName
+                                ? `${folderName}/${tempDirContents[i]}`
+                                : tempDirContents[i]
+                        );
                     }
                 }
-                
-                testGeneratedFiles("");
-                expect(files).toEqual(expectedGeneratedComponentTemplateFiles);
-            });
-            test("should be able to run the build", () => {
-                expect(
-                    () => {
-                        execSync(`cd ${tempDir} && npm run build`);
-                    }
-                ).not.toThrow();
-            });
+            }
+            
+            testGeneratedFiles("");
+            expect(files).toEqual(expectedGeneratedComponentTemplateFiles);
         });
+        test("should be able to run the build", () => {
+            expect(
+                () => {
+                    execSync(`cd ${tempDir} && npm run build`);
+                }
+            ).not.toThrow();
+        });
+    });
+    test.describe("add-foundation-component", () => {
         test.describe("blank", () => {
             test.beforeAll(() => {
                 setup();
                 execSync(`cd ${tempDir} && npm run fast:init`);
                 setup();
-                execSync(`cd ${tempDir} && npm run fast:add-component:blank`);
+                execSync(`cd ${tempDir} && npm run fast:add-foundation-component:blank`);
             });
             test.afterAll(() => {
                 teardown();

--- a/specs/fast-cli.md
+++ b/specs/fast-cli.md
@@ -126,7 +126,7 @@ Argument | Shorthand | Description | Required | Options
 > Important: The user should be prompted if no design system is present when attempting to add a new component to run the command `fast add-design-system`.
 > Important: During implementation the `define.ts` which will be part of a components template may require a `package.json` update to include a list of `sideEffects`.
 
-## Add a foundation comopnent
+## Add a foundation component
 
 Foundation components are similar to adding a component except they are based on the `@microsoft/fast-foundation` templates. These are bundled with flexible styles to provide an easy method for component creation and modification.
 

--- a/specs/fast-cli.md
+++ b/specs/fast-cli.md
@@ -120,10 +120,11 @@ $ fast add-component
 
 Argument | Shorthand | Description | Required | Options
 ---------|-----------|-------------|----------|---------
-`--name <name>` | `-n <name>` | The name of the functionality to be added | Yes | |
 `--template <path/to/template>` | `-t <path/to/template>` | Template including HTML, CSS, and [other files](#component-templates) | No | `<path/to/template>` |
+`--name <name>` | `-n <name>` | The name of the component to be added | Yes | |
 
 > Important: The user should be prompted if no design system is present when attempting to add a new component to run the command `fast add-design-system`.
+
 > Important: During implementation the `define.ts` which will be part of a components template may require a `package.json` update to include a list of `sideEffects`.
 
 ## Add a foundation component
@@ -142,6 +143,7 @@ Argument | Shorthand | Description | Required | Options
 `--name <name>` | `-n <name>` | The name of the component to be added | Yes | |
 
 > Important: The user should be prompted if no design system is present when attempting to add a new component to run the command `fast add-design-system`.
+
 > Important: During implementation the `define.ts` which will be part of a components template may require a `package.json` update to include a list of `sideEffects`.
 
 ## Templates

--- a/specs/fast-cli.md
+++ b/specs/fast-cli.md
@@ -139,7 +139,7 @@ $ fast add-foundation-component
 Argument | Shorthand | Description | Required | Options
 ---------|-----------|-------------|----------|--------
 `--template <template>` | `-t <template>` | The name of the foundation element | Yes | "accordion", "anchor", "anchored-region", "avatar", "badge", "blank", "breadcrumb", "button", "calendar", "card", "checkbox", "combobox", "data-grid", "dialog", "disclosure", "divider", "flipper", "horizontal-scroll", "listbox", "menu", "number-field", "picker", "progress", "progress-ring", "radio-group", "search", "select", "skeleton", "slider", "switch", "tabs", "text-area", "text-field", "toolbar", "tooltip", "tree-view" |
-`--name <name>` | `-n <name>` | The name of the component to be added | Yes | The name of the foundation template |
+`--name <name>` | `-n <name>` | The name of the component to be added | Yes | |
 
 > Important: The user should be prompted if no design system is present when attempting to add a new component to run the command `fast add-design-system`.
 > Important: During implementation the `define.ts` which will be part of a components template may require a `package.json` update to include a list of `sideEffects`.

--- a/specs/fast-cli.md
+++ b/specs/fast-cli.md
@@ -110,7 +110,7 @@ export const designSystem = {
 
 ## Add a component
 
-Components are added and configured based on a design system. Templates can use either the "blank" template with the default files, or it can point to a local or remote package.
+Components are added and configured based on a design system. Templates can use either a local or remote package.
 
 ```bash
 $ fast add-component
@@ -120,7 +120,7 @@ $ fast add-component
 
 Argument | Shorthand | Description | Required | Options
 ---------|-----------|-------------|----------|---------
-`--template <path/to/template>` | `-t <path/to/template>` | Template including HTML, CSS, and [other files](#component-templates) | No | `<path/to/template>` |
+`--template <path/to/template>` | `-t <path/to/template>` | Template including HTML, CSS, and [other files](#component-templates) | Yes | `<path/to/template>` |
 `--name <name>` | `-n <name>` | The name of the component to be added | Yes | |
 
 > Important: The user should be prompted if no design system is present when attempting to add a new component to run the command `fast add-design-system`.

--- a/specs/fast-cli.md
+++ b/specs/fast-cli.md
@@ -136,7 +136,7 @@ $ fast add-foundation-component
 
 ### Arguments
 
-Argument | Shorthand | Description | Required | Default
+Argument | Shorthand | Description | Required | Options
 ---------|-----------|-------------|----------|--------
 `--template <template>` | `-t <template>` | The name of the foundation element | Yes | "accordion", "anchor", "anchored-region", "avatar", "badge", "blank", "breadcrumb", "button", "calendar", "card", "checkbox", "combobox", "data-grid", "dialog", "disclosure", "divider", "flipper", "horizontal-scroll", "listbox", "menu", "number-field", "picker", "progress", "progress-ring", "radio-group", "search", "select", "skeleton", "slider", "switch", "tabs", "text-area", "text-field", "toolbar", "tooltip", "tree-view" |
 `--name <name>` | `-n <name>` | The name of the component to be added | Yes | The name of the foundation template |

--- a/specs/fast-cli.md
+++ b/specs/fast-cli.md
@@ -121,11 +121,22 @@ $ fast add-component
 Argument | Shorthand | Description | Required | Options
 ---------|-----------|-------------|----------|---------
 `--name <name>` | `-n <name>` | The name of the functionality to be added | Yes | |
-`--template <path/to/template>` | `-t <path/to/template>` | Template including HTML, CSS, and [other files](#component-templates) | No | `<path/to/template>`, "blank" |
+`--template <path/to/template>` | `-t <path/to/template>` | Template including HTML, CSS, and [other files](#component-templates) | No | `<path/to/template>` |
 
 > Important: The user should be prompted if no design system is present when attempting to add a new component to run the command `fast add-design-system`.
 
 > Important: During implementation the `define.ts` which will be part of a components template may require a `package.json` update to include a list of `sideEffects`.
+
+Should no template or foundation component be selected, a blank component will be created.
+
+TBD list available foundation components.
+
+> Important: The user should be prompted if no design system is present when attempting to add a new component to run the command `fast add-design-system`.
+
+Argument | Shorthand | Description | Required | Default
+---------|-----------|-------------|----------|--------
+`--template <template>` | `-t <template>` | The name of the foundation element | Yes | "accordion", "anchor", "anchored-region", "avatar", "badge", "blank", "breadcrumb", "button", "calendar", "card", "checkbox", "combobox", "data-grid", "dialog", "disclosure", "divider", "flipper", "horizontal-scroll", "listbox", "menu", "number-field", "picker", "progress", "progress-ring", "radio-group", "search", "select", "skeleton", "slider", "switch", "tabs", "text-area", "text-field", "toolbar", "tooltip", "tree-view" |
+`--name <name>` | `-n <name>` | The name of the component to be added | Yes | The name of the foundation template |
 
 ## Add a foundation component
 

--- a/specs/fast-cli.md
+++ b/specs/fast-cli.md
@@ -124,32 +124,25 @@ Argument | Shorthand | Description | Required | Options
 `--template <path/to/template>` | `-t <path/to/template>` | Template including HTML, CSS, and [other files](#component-templates) | No | `<path/to/template>` |
 
 > Important: The user should be prompted if no design system is present when attempting to add a new component to run the command `fast add-design-system`.
-
 > Important: During implementation the `define.ts` which will be part of a components template may require a `package.json` update to include a list of `sideEffects`.
 
-Should no template or foundation component be selected, a blank component will be created.
+## Add a foundation comopnent
 
-TBD list available foundation components.
+Foundation components are similar to adding a component except they are based on the `@microsoft/fast-foundation` templates. These are bundled with flexible styles to provide an easy method for component creation and modification.
 
-> Important: The user should be prompted if no design system is present when attempting to add a new component to run the command `fast add-design-system`.
+```bash
+$ fast add-foundation-component
+```
+
+### Arguments
 
 Argument | Shorthand | Description | Required | Default
 ---------|-----------|-------------|----------|--------
 `--template <template>` | `-t <template>` | The name of the foundation element | Yes | "accordion", "anchor", "anchored-region", "avatar", "badge", "blank", "breadcrumb", "button", "calendar", "card", "checkbox", "combobox", "data-grid", "dialog", "disclosure", "divider", "flipper", "horizontal-scroll", "listbox", "menu", "number-field", "picker", "progress", "progress-ring", "radio-group", "search", "select", "skeleton", "slider", "switch", "tabs", "text-area", "text-field", "toolbar", "tooltip", "tree-view" |
 `--name <name>` | `-n <name>` | The name of the component to be added | Yes | The name of the foundation template |
 
-## Add a foundation component
-
-Components are added and configured based on a design system and rely on a `@microsoft/fast-foundation` depenency.
-
-```bash
-$ fast add-foundation-component
-```
-
-Argument | Shorthand | Description | Required | Default
----------|-----------|-------------|----------|--------
-`--template <template>` | `-t <template>` | The name of the foundation element | Yes | "accordion", "anchor", "anchored-region", "avatar", "badge", "breadcrumb", "button", "calendar", "card", "checkbox", "combobox", "data-grid", "dialog", "disclosure", "divider", "flipper", "horizontal-scroll", "listbox", "menu", "number-field", "picker", "progress", "progress-ring", "radio-group", "search", "select", "skeleton", "slider", "switch", "tabs", "text-area", "text-field", "toolbar", "tooltip", "tree-view" |
-`--name <name>` | `-n <name>` | The name of the component to be added | Yes | The name of the foundation template |
+> Important: The user should be prompted if no design system is present when attempting to add a new component to run the command `fast add-design-system`.
+> Important: During implementation the `define.ts` which will be part of a components template may require a `package.json` update to include a list of `sideEffects`.
 
 ## Templates
 

--- a/website/docs/add-a-component.md
+++ b/website/docs/add-a-component.md
@@ -1,5 +1,8 @@
 # Add a component
 
+Adding a component from a template allows a user to leverage an `npm` package or a local template they have created themselves.
+
+## Command line
 ```bash
 $ fast add-component
 ```

--- a/website/docs/add-a-design-system.md
+++ b/website/docs/add-a-design-system.md
@@ -2,14 +2,20 @@
 
 Before adding your own components, a design system file must be available. The design system will dictate web component configuration options.
 
+## Command line
+
 ```bash
 $ fast add-design-system
 ```
+
+## Arguments
 
 Argument | Shorthand | Description | Required | Default | Options
 ---------|-----------|-------------|----------|---------|--------
 `--prefix <prefix>` | `-p <prefix>` | The web component prefix | No | `<project-name>` |
 `--shadow-root-mode <mode>` | `-s <mode>` | Determine what the shadowroot mode is | No | "open" | "closed", "open"
+
+## Generated files
 
 Example design-system.ts contents:
 ```ts

--- a/website/docs/add-a-foundation-component.md
+++ b/website/docs/add-a-foundation-component.md
@@ -1,0 +1,16 @@
+# Add a foundation comopnent
+
+Foundation components are similar to adding a component except they are based on the `@microsoft/fast-foundation` templates. These are bundled with flexible styles to provide an easy method for component creation and modification.
+
+## Command line
+
+```bash
+$ fast add-foundation-component
+```
+
+## Arguments
+
+Argument | Shorthand | Description | Required | Default
+---------|-----------|-------------|----------|--------
+`--template <template>` | `-t <template>` | The name of the foundation element | Yes | "accordion", "anchor", "anchored-region", "avatar", "badge", "blank", "breadcrumb", "button", "calendar", "card", "checkbox", "combobox", "data-grid", "dialog", "disclosure", "divider", "flipper", "horizontal-scroll", "listbox", "menu", "number-field", "picker", "progress", "progress-ring", "radio-group", "search", "select", "skeleton", "slider", "switch", "tabs", "text-area", "text-field", "toolbar", "tooltip", "tree-view" |
+`--name <name>` | `-n <name>` | The name of the component to be added | Yes | The name of the foundation template |

--- a/website/docs/configure.md
+++ b/website/docs/configure.md
@@ -2,18 +2,21 @@
 
 Running the `config` command will create a `fastconfig.json` file. This should be useful in existing projects which could take advantage of the CLI once it has been initialized.
 
+## Command line
+
 ```bash
 $ fast config
 ```
 
-### Arguments
+## Arguments
 
 Argument | Shorthand | Description | Required | Default |
 ---------|-----------|-------------|----------|---------|
 `--component-path <path/to/components>` | `-p <path/to/components>` | The relative path of the FAST components folder | Yes | |
 
-### Example fastconfig.json file
+## Generated files
 
+Example fastconfig.json file:
 ```json
 {
     "componentPath": "./src/components"

--- a/website/docs/initialize.md
+++ b/website/docs/initialize.md
@@ -20,7 +20,7 @@ Install the `@microsoft/fast-cli` locally or globally.
 $ fast init
 ```
 
-### Arguments
+## Arguments
 
 Argument | Shorthand | Description | Required
 ---------|-----------|-------------|---------

--- a/website/docs/sidebar.js
+++ b/website/docs/sidebar.js
@@ -53,6 +53,11 @@ export default {
             path: "add-a-component",
         },
         {
+            type: "doc",
+            label: "Add a foundation component",
+            path: "add-a-foundation-component",
+        },
+        {
             type: "category",
             label: "Templates",
             path: "templates",
@@ -64,6 +69,6 @@ export default {
                     path: "templates/component"
                 }
             ]
-        }
+        },
     ],
 };

--- a/website/docs/templates/component.md
+++ b/website/docs/templates/component.md
@@ -15,3 +15,15 @@ template/
 └─ define.ts
 └─ fast.add-component.json
 └─ README.ts
+
+## File contents
+
+Each file should contain a default export, using the `ComponentTemplateConfig` as an argument.
+
+```ts
+import type { ComponentTemplateConfig } from "@microsoft/fast-cli";
+
+export default (config: ComponentTemplateConfig): string => `...your template`;
+```
+
+<!-- TODO: add api-extractor information for the ComopnentTemplateConfig -->


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This update does the following:
- Adds the `add-foundation-component` command
- Adds the "blank" template to the list of foundation components
- Updates the documentation to normalize it
- Adds the documentation for the `add-foundation-component` command

### 🎫 Issues

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->
Partially takes care of #31

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.
-->
In order to not have a massive PR down the line, foundation components will be added individually as PRs. This PR only takes care of the command line option and moves the tests around to better facilitate this update.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
- Add each foundation component