### PR TITLE
Moved the prefix argument to the config command

### DIFF
--- a/change/@microsoft-fast-cli-f5f2d33e-204c-453b-b1c7-8b4fca1f996b.json
+++ b/change/@microsoft-fast-cli-f5f2d33e-204c-453b-b1c7-8b4fca1f996b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Moved the prefix argument to the config command",
+  "packageName": "@microsoft/fast-cli",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-cli/src/cli.options.ts
+++ b/packages/fast-cli/src/cli.options.ts
@@ -1,11 +1,13 @@
 export interface FastConfig {
     componentPath: string;
     rootDir: string;
+    prefix: string;
 }
 
 export interface FastConfigOptionMessages {
     componentPath: string;
     rootDir: string;
+    prefix: string;
 }
 
 export interface PackageJsonInit {
@@ -38,12 +40,10 @@ export interface FastInitOptionMessages {
 }
 
 export interface AddDesignSystemOptions {
-    prefix?: string;
     shadowRootMode?: "open" | "closed";
 }
 
 export interface AddDesignSystemOptionMessages {
-    prefix: string;
     shadowRootMode: string;
 }
 

--- a/packages/fast-cli/src/cli.ts
+++ b/packages/fast-cli/src/cli.ts
@@ -59,6 +59,11 @@ interface ConfigOptions {
      * The root directory
      */
     rootDir: string;
+
+    /**
+     * The web components prefix
+     */
+    prefix: string;
 }
 
 /**
@@ -328,7 +333,7 @@ async function createDesignSystemFile(
         `import { DesignSystem } from "@microsoft/fast-foundation";\n` +
         `import components from "${fastConfig.componentPath}/index.js";\n\n` +
         `export const designSystem = {\n` +
-        `    prefix: "${designSystemOptions.prefix}",\n` +
+        `    prefix: "${fastConfig.prefix}",\n` +
         `    shadowRootMode: "${designSystemOptions.shadowRootMode}",\n` +
         `};\n\n` +
         `DesignSystem.getOrCreate().withPrefix(\n` +
@@ -368,19 +373,6 @@ async function addDesignSystem(
     messages: AddDesignSystemOptionMessages
 ): Promise<void> {
     const config: AddDesignSystemOptions = options;
-
-    if (!options.prefix) {
-        config.prefix = await prompts([
-            {
-                type: "text",
-                name: "prefix",
-                message: messages.prefix,
-                validate: (input): boolean => {
-                    return input !== "";
-                }
-            }
-        ]).prefix;
-    }
 
     if (!options.shadowRootMode) {
         config.shadowRootMode = await prompts([
@@ -595,6 +587,19 @@ async function config(options: ConfigOptions, messages: FastConfigOptionMessages
         ]).rootDir;
     }
 
+    if (!options.prefix) {
+        config.prefix = await prompts([
+            {
+                type: "text",
+                name: "prefix",
+                message: messages.prefix,
+                validate: (input): boolean => {
+                    return input !== "";
+                }
+            }
+        ]).prefix;
+    }
+
     createConfigFile(config);
 }
 
@@ -656,13 +661,16 @@ program
 
 const configComponentPathMessage: string = "Path to component folder";
 const configRootDirMessage: string = "Root directory";
+const configPrefixMessage: string = "The web component prefix";
 
 program.command("config")
     .description("Configure a project")
+    .option("-n, --prefix <prefix>", configPrefixMessage)
     .option("-p, --component-path <path/to/components>", configComponentPathMessage)
     .option("-r, --root-dir <path/to/root>", configRootDirMessage)
     .action(async (options): Promise<void> => {
         await config(options, {
+            prefix: configPrefixMessage,
             componentPath: configComponentPathMessage,
             rootDir: configRootDirMessage
         }).catch((reason) => {
@@ -670,16 +678,13 @@ program.command("config")
         });
     });
 
-const addDesignSystemPrefixMessage: string = "The web component prefix";
 const addDesignSystemShadowRootModeMessage: string = "The shadowroot mode";
 
 program.command("add-design-system")
     .description("Add a design system")
-    .option("-p, --prefix <prefix>", addDesignSystemPrefixMessage)
     .option("-s, --shadow-root-mode <mode>", addDesignSystemShadowRootModeMessage)
     .action(async (options): Promise<void> => {
         await addDesignSystem(options, {
-            prefix: addDesignSystemPrefixMessage,
             shadowRootMode: addDesignSystemShadowRootModeMessage,
         }).catch((reason) => {
             throw reason;

--- a/packages/fast-cli/src/test/helpers.ts
+++ b/packages/fast-cli/src/test/helpers.ts
@@ -27,8 +27,8 @@ export function setup(tempDir: string, tempComponentDir: string): void {
     packageJson.scripts = {
         ...packageJson.scripts,
         "fast:init": `fast init -t ${path.resolve(dirname, "cfp-template")}`,
-        "fast:config": `fast config -p ./components -r ./src`,
-        "fast:add-design-system": `fast add-design-system -p test -s open`,
+        "fast:config": `fast config -p ./components -r ./src -n test`,
+        "fast:add-design-system": `fast add-design-system -s open`,
         "fast:add-component:template": `fast add-component -n test-component -t ${tempComponentDir}`,
         ...availableTemplates.reduce((prevValue, currValue: string) => {
             return {

--- a/website/docs/add-a-design-system.md
+++ b/website/docs/add-a-design-system.md
@@ -12,7 +12,6 @@ $ fast add-design-system
 
 Argument | Shorthand | Description | Required | Default | Options
 ---------|-----------|-------------|----------|---------|--------
-`--prefix <prefix>` | `-p <prefix>` | The web component prefix | No | `<project-name>` |
 `--shadow-root-mode <mode>` | `-s <mode>` | Determine what the shadowroot mode is | No | "open" | "closed", "open"
 
 ## Generated files

--- a/website/docs/configure.md
+++ b/website/docs/configure.md
@@ -13,15 +13,16 @@ $ fast config
 Argument | Shorthand | Description | Required | Default |
 ---------|-----------|-------------|----------|---------|
 `--component-path <path/to/components>` | `-p <path/to/components>` | The relative path of the FAST components folder | Yes | |
-`--root-dir <path/to/directory>` | `-r <path/to/directory` | The root directory of the code. | Yes | |
+`--root-dir <path/to/directory>` | `-r <path/to/directory` | The root directory of the code where the design system may be found. | Yes | |
+`--prefix <name>` | `-n <name>` | The components prefix | Yes | |
 
 ## Generated files
 
 Example fast.config.json file:
 ```json
 {
-    "componentPath": "./src/components"
+    "rootDir": "./src",
+    "componentPath": "./src/components",
+    "prefix": "fast"
 }
 ```
-
-> Important: The paths of components and design system must be relative to each other, therefore only the path to the component folder is required as the design system file path is assumed. In an app the path may be `"./src/components"` as shown above, or in the case of a component library the path may be `"./src"`.

--- a/website/docs/templates/project.md
+++ b/website/docs/templates/project.md
@@ -1,0 +1,33 @@
+# Project templates
+
+These templates will be used in the `init` command. Create your own and refer to them locally, or publish an `npm` package and install via the package name. The default template is the `@microsoft/cfp-template`.
+
+## Required folder and files
+
+```
+template/
+    fast.init.json
+```
+
+## `fast.init.json`
+
+The contents of the file should contain
+
+### `fastConfig`
+
+The `fastConfig` property should be a subset of the [FAST configuration](https://microsoft.github.io/fast-cli/docs/configure/).
+
+Example:
+```json
+{
+    "fastConfig": {
+        "rootDir": "./src",
+        "componentPath": "./components",
+        "prefix": "fast"
+    }
+}
+```
+
+### `packageJson`
+
+The `packageJson` property should contain all of the package information for the initialized property. Refer to [npm documentation](https://docs.npmjs.com/cli/v8/configuring-npm/package-json) for details.


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This change updates the following documentation:
- project template documentation
- design-system command documentation
- config command documentation

It also moves the `prefix` configuration option to the config command.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
- Convert the configuration files to `ts` with default exports instead of using `.json` so that they can be imported without any additional configuration settings.