### PR TITLE
Added name checking to ensure name collisions do not happen

### DIFF
--- a/change/@microsoft-fast-cli-038ba026-8429-4bd5-a8c6-e633f3878fa9.json
+++ b/change/@microsoft-fast-cli-038ba026-8429-4bd5-a8c6-e633f3878fa9.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added name checking to ensure name collisions do not happen",
+  "packageName": "@microsoft/fast-cli",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-cli/playwright.config.ts
+++ b/packages/fast-cli/playwright.config.ts
@@ -3,6 +3,7 @@ import type { PlaywrightTestConfig } from "@playwright/test";
 const config: PlaywrightTestConfig = {
     testDir: "dist",
     testMatch: "**/?(*.)+(spec).+(js)",
+    retries: process.env.CI ? 2 : 0,
     webServer: {
         command: "npm run serve:storybook",
         port: 3000,

--- a/packages/fast-cli/src/cli.spec.ts
+++ b/packages/fast-cli/src/cli.spec.ts
@@ -4,7 +4,7 @@ import path from "path";
 import fs from "fs-extra";
 import {
     dirname,
-    expectedGeneratedComponentTemplateFiles,
+    getExpectedGeneratedComponentTemplateFiles,
     getTempDir,
     getTempComponentDir,
     setup,
@@ -207,7 +207,7 @@ test.describe("CLI", () => {
             }
             
             testGeneratedFiles("");
-            expect(files).toEqual(expectedGeneratedComponentTemplateFiles);
+            expect(files.sort()).toEqual(getExpectedGeneratedComponentTemplateFiles("test-component").sort());
         });
         test("should be able to run the build", () => {
             expect(

--- a/packages/fast-cli/src/components/accordion-item/template.pw.spec.ts
+++ b/packages/fast-cli/src/components/accordion-item/template.pw.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { execSync } from "child_process";
 import {
-    expectedGeneratedComponentTemplateFiles,
+    getExpectedGeneratedComponentTemplateFiles,
     setupComponent,
     teardown,
     getGeneratedComponentFiles,
@@ -21,7 +21,7 @@ test.describe(`CLI add-foundation-component ${uuid}`, () => {
         teardown(tempDir, tempComponentDir);
     });
     test("should copy files from the template", () => {
-        expect(getGeneratedComponentFiles(tempDir)).toEqual(expectedGeneratedComponentTemplateFiles);
+        expect(getGeneratedComponentFiles(tempDir, uuid).sort()).toEqual(getExpectedGeneratedComponentTemplateFiles(uuid).sort());
     });
     test("should be able to run the build", () => {
         expect(

--- a/packages/fast-cli/src/components/accordion-item/template/component.template.ts
+++ b/packages/fast-cli/src/components/accordion-item/template/component.template.ts
@@ -1,12 +1,12 @@
 import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string => `
-import { AccordionItem, accordionItemTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
+import { AccordionItem as FoundationAccordionItem, accordionItemTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
 import type { ViewTemplate } from "@microsoft/fast-element";
 
 /**
  * The template for ${config.className} component.
  * @public
  */
-export const template: FoundationElementTemplate<ViewTemplate<AccordionItem>> = accordionItemTemplate;
+export const template: FoundationElementTemplate<ViewTemplate<FoundationAccordionItem>> = accordionItemTemplate;
 `;

--- a/packages/fast-cli/src/components/accordion-item/template/component.ts
+++ b/packages/fast-cli/src/components/accordion-item/template/component.ts
@@ -2,9 +2,9 @@ import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string =>
 `import { attr } from "@microsoft/fast-element";
-import { AccordionItem } from "@microsoft/fast-foundation";
+import { AccordionItem as FoundationAccordionItem } from "@microsoft/fast-foundation";
 
 /**
- * A class derived from the AccordionItem foundation component
+ * A class derived from the FoundationAccordionItem foundation component
  */
-export class ${config.className} extends AccordionItem {};`
+export class ${config.className} extends FoundationAccordionItem {};`

--- a/packages/fast-cli/src/components/accordion/template.pw.spec.ts
+++ b/packages/fast-cli/src/components/accordion/template.pw.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { execSync } from "child_process";
 import {
-    expectedGeneratedComponentTemplateFiles,
+    getExpectedGeneratedComponentTemplateFiles,
     setupComponent,
     teardown,
     getGeneratedComponentFiles,
@@ -21,7 +21,7 @@ test.describe(`CLI add-foundation-component ${uuid}`, () => {
         teardown(tempDir, tempComponentDir);
     });
     test("should copy files from the template", () => {
-        expect(getGeneratedComponentFiles(tempDir)).toEqual(expectedGeneratedComponentTemplateFiles);
+        expect(getGeneratedComponentFiles(tempDir, uuid).sort()).toEqual(getExpectedGeneratedComponentTemplateFiles(uuid).sort());
     });
     test("should be able to run the build", () => {
         expect(

--- a/packages/fast-cli/src/components/accordion/template/component.template.ts
+++ b/packages/fast-cli/src/components/accordion/template/component.template.ts
@@ -1,12 +1,12 @@
 import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string => `
-import { Accordion, accordionTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
+import { Accordion as FoundationAccordion, accordionTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
 import type { ViewTemplate } from "@microsoft/fast-element";
 
 /**
  * The template for ${config.className} component.
  * @public
  */
-export const template: FoundationElementTemplate<ViewTemplate<Accordion>> = accordionTemplate;
+export const template: FoundationElementTemplate<ViewTemplate<FoundationAccordion>> = accordionTemplate;
 `;

--- a/packages/fast-cli/src/components/accordion/template/component.ts
+++ b/packages/fast-cli/src/components/accordion/template/component.ts
@@ -2,9 +2,9 @@ import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string =>
 `import { attr } from "@microsoft/fast-element";
-import { Accordion } from "@microsoft/fast-foundation";
+import { Accordion as FoundationAccordion } from "@microsoft/fast-foundation";
 
 /**
  * A class derived from the Accordion foundation component
  */
-export class ${config.className} extends Accordion {};`
+export class ${config.className} extends FoundationAccordion {};`

--- a/packages/fast-cli/src/components/avatar/template.pw.spec.ts
+++ b/packages/fast-cli/src/components/avatar/template.pw.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { execSync } from "child_process";
 import {
-    expectedGeneratedComponentTemplateFiles,
+    getExpectedGeneratedComponentTemplateFiles,
     setupComponent,
     teardown,
     getGeneratedComponentFiles,
@@ -21,7 +21,7 @@ test.describe(`CLI add-foundation-component ${uuid}`, () => {
         teardown(tempDir, tempComponentDir);
     });
     test("should copy files from the template", () => {
-        expect(getGeneratedComponentFiles(tempDir)).toEqual(expectedGeneratedComponentTemplateFiles);
+        expect(getGeneratedComponentFiles(tempDir, uuid).sort()).toEqual(getExpectedGeneratedComponentTemplateFiles(uuid).sort());
     });
     test("should be able to run the build", () => {
         expect(

--- a/packages/fast-cli/src/components/avatar/template/component.definition.ts
+++ b/packages/fast-cli/src/components/avatar/template/component.definition.ts
@@ -5,11 +5,11 @@ export default (config: ComponentTemplateConfig): string =>
 import { styles } from "./${config.tagName}.styles.js";
 import type { ${config.className} } from "./${config.tagName}.js";
 import { html, when } from "@microsoft/fast-element";
-import { Avatar } from "@microsoft/fast-foundation";
+import { Avatar as FoundationAvatar } from "@microsoft/fast-foundation";
 
 export const definition = {
     baseName: "${config.tagName}",
-    baseClass: Avatar,
+    baseClass: FoundationAvatar,
     template,
     styles,
     media: html<${config.className}>\`

--- a/packages/fast-cli/src/components/avatar/template/component.template.ts
+++ b/packages/fast-cli/src/components/avatar/template/component.template.ts
@@ -1,12 +1,12 @@
 import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string => `
-import { Avatar, avatarTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
+import { Avatar as FoundationAvatar, avatarTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
 import type { ViewTemplate } from "@microsoft/fast-element";
 
 /**
  * The template for ${config.className} component.
  * @public
  */
-export const template: FoundationElementTemplate<ViewTemplate<Avatar>> = avatarTemplate;
+export const template: FoundationElementTemplate<ViewTemplate<FoundationAvatar>> = avatarTemplate;
 `;

--- a/packages/fast-cli/src/components/avatar/template/component.ts
+++ b/packages/fast-cli/src/components/avatar/template/component.ts
@@ -2,12 +2,12 @@ import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string =>
 `import { attr } from "@microsoft/fast-element";
-import { Avatar } from "@microsoft/fast-foundation";
+import { Avatar as FoundationAvatar } from "@microsoft/fast-foundation";
 
 /**
  * A class derived from the Avatar foundation component
  */
-export class ${config.className} extends Avatar {
+export class ${config.className} extends FoundationAvatar {
     /**
      * Indicates the Avatar should have an image source
      *

--- a/packages/fast-cli/src/components/badge/template.pw.spec.ts
+++ b/packages/fast-cli/src/components/badge/template.pw.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { execSync } from "child_process";
 import {
-    expectedGeneratedComponentTemplateFiles,
+    getExpectedGeneratedComponentTemplateFiles,
     setupComponent,
     teardown,
     getGeneratedComponentFiles,
@@ -21,7 +21,7 @@ test.describe(`CLI add-foundation-component ${uuid}`, () => {
         teardown(tempDir, tempComponentDir);
     });
     test("should copy files from the template", () => {
-        expect(getGeneratedComponentFiles(tempDir)).toEqual(expectedGeneratedComponentTemplateFiles);
+        expect(getGeneratedComponentFiles(tempDir, uuid).sort()).toEqual(getExpectedGeneratedComponentTemplateFiles(uuid).sort());
     });
     test("should be able to run the build", () => {
         expect(

--- a/packages/fast-cli/src/components/badge/template/component.template.ts
+++ b/packages/fast-cli/src/components/badge/template/component.template.ts
@@ -1,12 +1,12 @@
 import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string => `
-import { Badge, badgeTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
+import { Badge as FoundationBadge, badgeTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
 import type { ViewTemplate } from "@microsoft/fast-element";
 
 /**
  * The template for ${config.className} component.
  * @public
  */
-export const template: FoundationElementTemplate<ViewTemplate<Badge>> = badgeTemplate;
+export const template: FoundationElementTemplate<ViewTemplate<FoundationBadge>> = badgeTemplate;
 `;

--- a/packages/fast-cli/src/components/badge/template/component.ts
+++ b/packages/fast-cli/src/components/badge/template/component.ts
@@ -1,9 +1,9 @@
 import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string =>
-`import { Badge } from "@microsoft/fast-foundation";
+`import { Badge as FoundationBadge } from "@microsoft/fast-foundation";
 
 /**
  * A class derived from the Badge foundation component
  */
-export class ${config.className} extends Badge {};`
+export class ${config.className} extends FoundationBadge {};`

--- a/packages/fast-cli/src/components/blank/template.pw.spec.ts
+++ b/packages/fast-cli/src/components/blank/template.pw.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { execSync } from "child_process";
 import {
-    expectedGeneratedComponentTemplateFiles,
+    getExpectedGeneratedComponentTemplateFiles,
     setupComponent,
     teardown,
     getGeneratedComponentFiles,
@@ -21,7 +21,7 @@ test.describe(`CLI add-foundation-component ${uuid}`, () => {
         teardown(tempDir, tempComponentDir);
     });
     test("should copy files from the template", () => {
-        expect(getGeneratedComponentFiles(tempDir)).toEqual(expectedGeneratedComponentTemplateFiles);
+        expect(getGeneratedComponentFiles(tempDir, uuid).sort()).toEqual(getExpectedGeneratedComponentTemplateFiles(uuid).sort());
     });
     test("should be able to run the build", () => {
         expect(

--- a/packages/fast-cli/src/components/calendar/template.pw.spec.ts
+++ b/packages/fast-cli/src/components/calendar/template.pw.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { execSync } from "child_process";
 import {
-    expectedGeneratedComponentTemplateFiles,
+    getExpectedGeneratedComponentTemplateFiles,
     setupComponent,
     teardown,
     getGeneratedComponentFiles,
@@ -21,7 +21,7 @@ test.describe(`CLI add-foundation-component ${uuid}`, () => {
         teardown(tempDir, tempComponentDir);
     });
     test("should copy files from the template", () => {
-        expect(getGeneratedComponentFiles(tempDir)).toEqual(expectedGeneratedComponentTemplateFiles);
+        expect(getGeneratedComponentFiles(tempDir, uuid).sort()).toEqual(getExpectedGeneratedComponentTemplateFiles(uuid).sort());
     });
     test("should be able to run the build", () => {
         expect(

--- a/packages/fast-cli/src/components/calendar/template/component.template.ts
+++ b/packages/fast-cli/src/components/calendar/template/component.template.ts
@@ -1,12 +1,12 @@
 import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string => `
-import { Calendar, calendarTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
+import { Calendar as FoundationCalendar, calendarTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
 import type { ViewTemplate } from "@microsoft/fast-element";
 
 /**
  * The template for ${config.className} component.
  * @public
  */
-export const template: FoundationElementTemplate<ViewTemplate<Calendar>> = calendarTemplate;
+export const template: FoundationElementTemplate<ViewTemplate<FoundationCalendar>> = calendarTemplate;
 `;

--- a/packages/fast-cli/src/components/calendar/template/component.ts
+++ b/packages/fast-cli/src/components/calendar/template/component.ts
@@ -1,9 +1,9 @@
 import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string =>
-`import { Calendar } from "@microsoft/fast-foundation";
+`import { Calendar as FoundationCalendar } from "@microsoft/fast-foundation";
 
 /**
  * A class derived from the Calendar foundation component
  */
-export class ${config.className} extends Calendar {};`
+export class ${config.className} extends FoundationCalendar {};`

--- a/packages/fast-cli/src/components/card/template.pw.spec.ts
+++ b/packages/fast-cli/src/components/card/template.pw.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { execSync } from "child_process";
 import {
-    expectedGeneratedComponentTemplateFiles,
+    getExpectedGeneratedComponentTemplateFiles,
     setupComponent,
     teardown,
     getGeneratedComponentFiles,
@@ -21,7 +21,7 @@ test.describe(`CLI add-foundation-component ${uuid}`, () => {
         teardown(tempDir, tempComponentDir);
     });
     test("should copy files from the template", () => {
-        expect(getGeneratedComponentFiles(tempDir)).toEqual(expectedGeneratedComponentTemplateFiles);
+        expect(getGeneratedComponentFiles(tempDir, uuid).sort()).toEqual(getExpectedGeneratedComponentTemplateFiles(uuid).sort());
     });
     test("should be able to run the build", () => {
         expect(

--- a/packages/fast-cli/src/components/card/template/component.template.ts
+++ b/packages/fast-cli/src/components/card/template/component.template.ts
@@ -1,11 +1,11 @@
 import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string => `
-import { Card, cardTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
+import { Card as FoundationCard, cardTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
 import type { ViewTemplate } from "@microsoft/fast-element";
 /**
  * The template for ${config.className} component.
  * @public
  */
-export const template: FoundationElementTemplate<ViewTemplate<Card>> = cardTemplate;
+export const template: FoundationElementTemplate<ViewTemplate<FoundationCard>> = cardTemplate;
 `; 

--- a/packages/fast-cli/src/components/card/template/component.ts
+++ b/packages/fast-cli/src/components/card/template/component.ts
@@ -1,14 +1,14 @@
 import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string =>
-`import { composedParent, Card } from "@microsoft/fast-foundation";
+`import { composedParent, Card as FoundationCard } from "@microsoft/fast-foundation";
 import type { Swatch } from "@microsoft/adaptive-ui/dist/dts/color/swatch.d.js"
 import { fillColor, neutralFillLayerRecipe } from "@microsoft/adaptive-ui";
 
 /**
  * A class derived from the Card foundation component
  */
-export class ${config.className} extends Card {
+export class ${config.className} extends FoundationCard {
     connectedCallback() {
         super.connectedCallback();
 

--- a/packages/fast-cli/src/components/checkbox/template.pw.spec.ts
+++ b/packages/fast-cli/src/components/checkbox/template.pw.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { execSync } from "child_process";
 import {
-    expectedGeneratedComponentTemplateFiles,
+    getExpectedGeneratedComponentTemplateFiles,
     setupComponent,
     teardown,
     getGeneratedComponentFiles,
@@ -21,7 +21,7 @@ test.describe(`CLI add-foundation-component ${uuid}`, () => {
         teardown(tempDir, tempComponentDir);
     });
     test("should copy files from the template", () => {
-        expect(getGeneratedComponentFiles(tempDir)).toEqual(expectedGeneratedComponentTemplateFiles);
+        expect(getGeneratedComponentFiles(tempDir, uuid).sort()).toEqual(getExpectedGeneratedComponentTemplateFiles(uuid).sort());
     });
     test("should be able to run the build", () => {
         expect(

--- a/packages/fast-cli/src/components/checkbox/template/component.template.ts
+++ b/packages/fast-cli/src/components/checkbox/template/component.template.ts
@@ -1,11 +1,11 @@
 import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string => `
-import { Checkbox, checkboxTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
+import { Checkbox as FoundationCheckbox, checkboxTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
 import type { ViewTemplate } from "@microsoft/fast-element";
 /**
  * The template for ${config.className} component.
  * @public
  */
-export const template: FoundationElementTemplate<ViewTemplate<Checkbox>> = checkboxTemplate;
+export const template: FoundationElementTemplate<ViewTemplate<FoundationCheckbox>> = checkboxTemplate;
 `; 

--- a/packages/fast-cli/src/components/checkbox/template/component.ts
+++ b/packages/fast-cli/src/components/checkbox/template/component.ts
@@ -1,8 +1,8 @@
 import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string =>
-`import { Checkbox } from "@microsoft/fast-foundation";
+`import { Checkbox as FoundationCheckbox } from "@microsoft/fast-foundation";
 /**
  * A class derived from the Checkbox foundation component
  */
-export class ${config.className} extends Checkbox {};` 
+export class ${config.className} extends FoundationCheckbox {};` 

--- a/packages/fast-cli/src/components/dialog/template.pw.spec.ts
+++ b/packages/fast-cli/src/components/dialog/template.pw.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { execSync } from "child_process";
 import {
-    expectedGeneratedComponentTemplateFiles,
+    getExpectedGeneratedComponentTemplateFiles,
     setupComponent,
     teardown,
     getGeneratedComponentFiles,
@@ -21,7 +21,7 @@ test.describe(`CLI add-foundation-component ${uuid}`, () => {
         teardown(tempDir, tempComponentDir);
     });
     test("should copy files from the template", () => {
-        expect(getGeneratedComponentFiles(tempDir)).toEqual(expectedGeneratedComponentTemplateFiles);
+        expect(getGeneratedComponentFiles(tempDir, uuid).sort()).toEqual(getExpectedGeneratedComponentTemplateFiles(uuid).sort());
     });
     test("should be able to run the build", () => {
         expect(

--- a/packages/fast-cli/src/components/dialog/template/component.template.ts
+++ b/packages/fast-cli/src/components/dialog/template/component.template.ts
@@ -1,12 +1,12 @@
 import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string => `
-import { Dialog, dialogTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
+import { Dialog as FoundationDialog, dialogTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
 import type { ViewTemplate } from "@microsoft/fast-element";
 
 /**
  * The template for ${config.className} component.
  * @public
  */
-export const template: FoundationElementTemplate<ViewTemplate<Dialog>> = dialogTemplate;
-`; 
+export const template: FoundationElementTemplate<ViewTemplate<FoundationDialog>> = dialogTemplate;
+`;

--- a/packages/fast-cli/src/components/dialog/template/component.ts
+++ b/packages/fast-cli/src/components/dialog/template/component.ts
@@ -1,8 +1,8 @@
 import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string =>
-`import { Dialog } from "@microsoft/fast-foundation";
+`import { Dialog as FoundationDialog } from "@microsoft/fast-foundation";
 /**
  * A class derived from the Dialog foundation component
  */
-export class ${config.className} extends Dialog {};` 
+export class ${config.className} extends FoundationDialog {};` 

--- a/packages/fast-cli/src/components/disclosure/template.pw.spec.ts
+++ b/packages/fast-cli/src/components/disclosure/template.pw.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { execSync } from "child_process";
 import {
-    expectedGeneratedComponentTemplateFiles,
+    getExpectedGeneratedComponentTemplateFiles,
     setupComponent,
     teardown,
     getGeneratedComponentFiles,
@@ -21,7 +21,7 @@ test.describe(`CLI add-foundation-component ${uuid}`, () => {
         teardown(tempDir, tempComponentDir);
     });
     test("should copy files from the template", () => {
-        expect(getGeneratedComponentFiles(tempDir)).toEqual(expectedGeneratedComponentTemplateFiles);
+        expect(getGeneratedComponentFiles(tempDir, uuid).sort()).toEqual(getExpectedGeneratedComponentTemplateFiles(uuid).sort());
     });
     test("should be able to run the build", () => {
         expect(

--- a/packages/fast-cli/src/components/disclosure/template/component.template.ts
+++ b/packages/fast-cli/src/components/disclosure/template/component.template.ts
@@ -1,12 +1,12 @@
 import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string => `
-import { Disclosure, disclosureTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
+import { Disclosure as FoundationDisclosure, disclosureTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
 import type { ViewTemplate } from "@microsoft/fast-element";
 
 /**
  * The template for ${config.className} component.
  * @public
  */
-export const template: FoundationElementTemplate<ViewTemplate<Disclosure>> = disclosureTemplate;
+export const template: FoundationElementTemplate<ViewTemplate<FoundationDisclosure>> = disclosureTemplate;
 `;

--- a/packages/fast-cli/src/components/disclosure/template/component.ts
+++ b/packages/fast-cli/src/components/disclosure/template/component.ts
@@ -1,7 +1,7 @@
 import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string =>
-`import { Disclosure } from "@microsoft/fast-foundation";
+`import { Disclosure as FoundationDisclosure } from "@microsoft/fast-foundation";
 import { attr } from "@microsoft/fast-element";
 
 /**
@@ -13,7 +13,7 @@ export type DisclosureAppearance = "accent" | "lightweight";
 /**
  * A class derived from the Disclosure foundation component
  */
-export class ${config.className} extends Disclosure {
+export class ${config.className} extends FoundationDisclosure {
     /**
      * Disclosure default height
      */

--- a/packages/fast-cli/src/components/divider/template.pw.spec.ts
+++ b/packages/fast-cli/src/components/divider/template.pw.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { execSync } from "child_process";
 import {
-    expectedGeneratedComponentTemplateFiles,
+    getExpectedGeneratedComponentTemplateFiles,
     setupComponent,
     teardown,
     getGeneratedComponentFiles,
@@ -21,7 +21,7 @@ test.describe(`CLI add-foundation-component ${uuid}`, () => {
         teardown(tempDir, tempComponentDir);
     });
     test("should copy files from the template", () => {
-        expect(getGeneratedComponentFiles(tempDir)).toEqual(expectedGeneratedComponentTemplateFiles);
+        expect(getGeneratedComponentFiles(tempDir, uuid).sort()).toEqual(getExpectedGeneratedComponentTemplateFiles(uuid).sort());
     });
     test("should be able to run the build", () => {
         expect(

--- a/packages/fast-cli/src/components/divider/template/component.template.ts
+++ b/packages/fast-cli/src/components/divider/template/component.template.ts
@@ -1,12 +1,12 @@
 import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string => `
-import { Divider, dividerTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
+import { Divider as FoundationDivider, dividerTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
 import type { ViewTemplate } from "@microsoft/fast-element";
 
 /**
  * The template for ${config.className} component.
  * @public
  */
-export const template: FoundationElementTemplate<ViewTemplate<Divider>> = dividerTemplate;
+export const template: FoundationElementTemplate<ViewTemplate<FoundationDivider>> = dividerTemplate;
 `;

--- a/packages/fast-cli/src/components/divider/template/component.ts
+++ b/packages/fast-cli/src/components/divider/template/component.ts
@@ -1,9 +1,9 @@
 import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string =>
-`import { Divider } from "@microsoft/fast-foundation";
+`import { Divider as FoundationDivider } from "@microsoft/fast-foundation";
 
 /**
  * A class derived from the Divider foundation component
  */
-export class ${config.className} extends Divider {};`
+export class ${config.className} extends FoundationDivider {};`

--- a/packages/fast-cli/src/components/flipper/template.pw.spec.ts
+++ b/packages/fast-cli/src/components/flipper/template.pw.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { execSync } from "child_process";
 import {
-    expectedGeneratedComponentTemplateFiles,
+    getExpectedGeneratedComponentTemplateFiles,
     setupComponent,
     teardown,
     getGeneratedComponentFiles,
@@ -21,7 +21,7 @@ test.describe(`CLI add-foundation-component ${uuid}`, () => {
         teardown(tempDir, tempComponentDir);
     });
     test("should copy files from the template", () => {
-        expect(getGeneratedComponentFiles(tempDir)).toEqual(expectedGeneratedComponentTemplateFiles);
+        expect(getGeneratedComponentFiles(tempDir, uuid).sort()).toEqual(getExpectedGeneratedComponentTemplateFiles(uuid).sort());
     });
     test("should be able to run the build", () => {
         expect(

--- a/packages/fast-cli/src/components/flipper/template/component.template.ts
+++ b/packages/fast-cli/src/components/flipper/template/component.template.ts
@@ -1,12 +1,12 @@
 import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string => 
-`import { Flipper, flipperTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
+`import { Flipper as FoundationFlipper, flipperTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
 import type { ViewTemplate } from "@microsoft/fast-element";
 
 /**
  * The template for ${config.className} component.
  * @public
  */
-export const template: FoundationElementTemplate<ViewTemplate<Flipper>> = flipperTemplate;
+export const template: FoundationElementTemplate<ViewTemplate<FoundationFlipper>> = flipperTemplate;
 `; 

--- a/packages/fast-cli/src/components/flipper/template/component.ts
+++ b/packages/fast-cli/src/components/flipper/template/component.ts
@@ -1,8 +1,8 @@
 import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string =>
-`import { Flipper } from "@microsoft/fast-foundation";
+`import { Flipper as FoundationFlipper } from "@microsoft/fast-foundation";
 /**
  * A class derived from the Flipper foundation component
  */
-export class ${config.className} extends Flipper {};` 
+export class ${config.className} extends FoundationFlipper {};` 

--- a/packages/fast-cli/src/components/number-field/template.pw.spec.ts
+++ b/packages/fast-cli/src/components/number-field/template.pw.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { execSync } from "child_process";
 import {
-    expectedGeneratedComponentTemplateFiles,
+    getExpectedGeneratedComponentTemplateFiles,
     setupComponent,
     teardown,
     getGeneratedComponentFiles,
@@ -21,7 +21,7 @@ test.describe(`CLI add-foundation-component ${uuid}`, () => {
         teardown(tempDir, tempComponentDir);
     });
     test("should copy files from the template", () => {
-        expect(getGeneratedComponentFiles(tempDir)).toEqual(expectedGeneratedComponentTemplateFiles);
+        expect(getGeneratedComponentFiles(tempDir, uuid).sort()).toEqual(getExpectedGeneratedComponentTemplateFiles(uuid).sort());
     });
     test("should be able to run the build", () => {
         expect(

--- a/packages/fast-cli/src/components/number-field/template/component.template.ts
+++ b/packages/fast-cli/src/components/number-field/template/component.template.ts
@@ -1,12 +1,12 @@
 import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string => `
-import { NumberField, numberFieldTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
+import { NumberField as FoundationNumberField, numberFieldTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
 import type { ViewTemplate } from "@microsoft/fast-element";
 
 /**
  * The template for ${config.className} component.
  * @public
  */
-export const template: FoundationElementTemplate<ViewTemplate<NumberField>> = numberFieldTemplate;
+export const template: FoundationElementTemplate<ViewTemplate<FoundationNumberField>> = numberFieldTemplate;
 `; 

--- a/packages/fast-cli/src/components/number-field/template/component.ts
+++ b/packages/fast-cli/src/components/number-field/template/component.ts
@@ -1,7 +1,7 @@
 import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string =>
-`import { NumberField } from "@microsoft/fast-foundation";
+`import { NumberField as FoundationNumberField } from "@microsoft/fast-foundation";
 import { attr } from "@microsoft/fast-element";
 
 /**
@@ -13,7 +13,7 @@ export type NumberFieldAppearance = "filled" | "outline";
 /**
  * A class derived from the NumberField foundation component
  */
-export class ${config.className} extends NumberField {
+export class ${config.className} extends FoundationNumberField {
     /**
      * The appearance of the element.
      *

--- a/packages/fast-cli/src/components/options.ts
+++ b/packages/fast-cli/src/components/options.ts
@@ -34,6 +34,31 @@ export const suggestedTemplates = [
 ];
 
 /**
+ * The disallowed names for templates to prevent
+ * naming conflicts
+ */
+export const disallowedTemplateNames = [
+    "foundation-accordion",
+    "foundation-avatar",
+    "foundation-badge",
+    "foundation-calendar",
+    "foundation-card",
+    "foundation-checkbox",
+    "foundation-dialog",
+    "foundation-disclosure",
+    "foundation-divider",
+    "foundation-flipper",
+    "foundation-number-field",
+    "base-progress",
+    "foundation-search",
+    "foundation-switch",
+    "foundation-text-area",
+    "foundation-text-field",
+    "foundation-toolbar",
+    "foundation-tooltip"
+]
+
+/**
  * All available templates
  */
 export const availableTemplates = suggestedTemplates.concat(companionTemplates);

--- a/packages/fast-cli/src/components/progress-ring/template.pw.spec.ts
+++ b/packages/fast-cli/src/components/progress-ring/template.pw.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { execSync } from "child_process";
 import {
-    expectedGeneratedComponentTemplateFiles,
+    getExpectedGeneratedComponentTemplateFiles,
     setupComponent,
     teardown,
     getGeneratedComponentFiles,
@@ -21,7 +21,7 @@ test.describe(`CLI add-foundation-component ${uuid}`, () => {
         teardown(tempDir, tempComponentDir);
     });
     test("should copy files from the template", () => {
-        expect(getGeneratedComponentFiles(tempDir)).toEqual(expectedGeneratedComponentTemplateFiles);
+        expect(getGeneratedComponentFiles(tempDir, uuid).sort()).toEqual(getExpectedGeneratedComponentTemplateFiles(uuid).sort());
     });
     test("should be able to run the build", () => {
         expect(

--- a/packages/fast-cli/src/components/progress/template.pw.spec.ts
+++ b/packages/fast-cli/src/components/progress/template.pw.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { execSync } from "child_process";
 import {
-    expectedGeneratedComponentTemplateFiles,
+    getExpectedGeneratedComponentTemplateFiles,
     setupComponent,
     teardown,
     getGeneratedComponentFiles,
@@ -21,7 +21,7 @@ test.describe(`CLI add-foundation-component ${uuid}`, () => {
         teardown(tempDir, tempComponentDir);
     });
     test("should copy files from the template", () => {
-        expect(getGeneratedComponentFiles(tempDir)).toEqual(expectedGeneratedComponentTemplateFiles);
+        expect(getGeneratedComponentFiles(tempDir, uuid).sort()).toEqual(getExpectedGeneratedComponentTemplateFiles(uuid).sort());
     });
     test("should be able to run the build", () => {
         expect(

--- a/packages/fast-cli/src/components/search/template.pw.spec.ts
+++ b/packages/fast-cli/src/components/search/template.pw.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { execSync } from "child_process";
 import {
-    expectedGeneratedComponentTemplateFiles,
+    getExpectedGeneratedComponentTemplateFiles,
     setupComponent,
     teardown,
     getGeneratedComponentFiles,
@@ -21,7 +21,7 @@ test.describe(`CLI add-foundation-component ${uuid}`, () => {
         teardown(tempDir, tempComponentDir);
     });
     test("should copy files from the template", () => {
-        expect(getGeneratedComponentFiles(tempDir)).toEqual(expectedGeneratedComponentTemplateFiles);
+        expect(getGeneratedComponentFiles(tempDir, uuid).sort()).toEqual(getExpectedGeneratedComponentTemplateFiles(uuid).sort());
     });
     test("should be able to run the build", () => {
         expect(

--- a/packages/fast-cli/src/components/search/template/component.template.ts
+++ b/packages/fast-cli/src/components/search/template/component.template.ts
@@ -1,12 +1,12 @@
 import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string => `
-import { Search, searchTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
+import { Search as FoundationSearch, searchTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
 import type { ViewTemplate } from "@microsoft/fast-element";
 
 /**
  * The template for ${config.className} component.
  * @public
  */
-export const template: FoundationElementTemplate<ViewTemplate<Search>> = searchTemplate;
+export const template: FoundationElementTemplate<ViewTemplate<FoundationSearch>> = searchTemplate;
 `;

--- a/packages/fast-cli/src/components/search/template/component.ts
+++ b/packages/fast-cli/src/components/search/template/component.ts
@@ -1,7 +1,7 @@
 import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string =>
-`import { Search } from "@microsoft/fast-foundation";
+`import { Search as FoundationSearch } from "@microsoft/fast-foundation";
 import { attr } from "@microsoft/fast-element";
 
 /**
@@ -13,7 +13,7 @@ export type SearchAppearance = "filled" | "outline";
 /**
  * A class derived from the Search foundation component
  */
-export class ${config.className} extends Search {
+export class ${config.className} extends FoundationSearch {
     /**
      * The appearance of the element.
      *

--- a/packages/fast-cli/src/components/switch/template.pw.spec.ts
+++ b/packages/fast-cli/src/components/switch/template.pw.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { execSync } from "child_process";
 import {
-    expectedGeneratedComponentTemplateFiles,
+    getExpectedGeneratedComponentTemplateFiles,
     setupComponent,
     teardown,
     getGeneratedComponentFiles,
@@ -21,7 +21,7 @@ test.describe(`CLI add-foundation-component ${uuid}`, () => {
         teardown(tempDir, tempComponentDir);
     });
     test("should copy files from the template", () => {
-        expect(getGeneratedComponentFiles(tempDir)).toEqual(expectedGeneratedComponentTemplateFiles);
+        expect(getGeneratedComponentFiles(tempDir, uuid).sort()).toEqual(getExpectedGeneratedComponentTemplateFiles(uuid).sort());
     });
     test("should be able to run the build", () => {
         expect(

--- a/packages/fast-cli/src/components/switch/template/component.template.ts
+++ b/packages/fast-cli/src/components/switch/template/component.template.ts
@@ -1,12 +1,12 @@
 import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string => `
-import { Switch, switchTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
+import { Switch as FoundationSwitch, switchTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
 import type { ViewTemplate } from "@microsoft/fast-element";
 
 /**
  * The template for ${config.className} component.
  * @public
  */
-export const template: FoundationElementTemplate<ViewTemplate<Switch>> = switchTemplate;
+export const template: FoundationElementTemplate<ViewTemplate<FoundationSwitch>> = switchTemplate;
 `;

--- a/packages/fast-cli/src/components/switch/template/component.ts
+++ b/packages/fast-cli/src/components/switch/template/component.ts
@@ -1,9 +1,9 @@
 import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string =>
-`import { Switch } from "@microsoft/fast-foundation";
+`import { Switch as FoundationSwitch } from "@microsoft/fast-foundation";
 
 /**
  * A class derived from the Switch foundation component
  */
-export class ${config.className} extends Switch {};`
+export class ${config.className} extends FoundationSwitch {};`

--- a/packages/fast-cli/src/components/text-area/template.pw.spec.ts
+++ b/packages/fast-cli/src/components/text-area/template.pw.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { execSync } from "child_process";
 import {
-    expectedGeneratedComponentTemplateFiles,
+    getExpectedGeneratedComponentTemplateFiles,
     setupComponent,
     teardown,
     getGeneratedComponentFiles,
@@ -21,7 +21,7 @@ test.describe(`CLI add-foundation-component ${uuid}`, () => {
         teardown(tempDir, tempComponentDir);
     });
     test("should copy files from the template", () => {
-        expect(getGeneratedComponentFiles(tempDir)).toEqual(expectedGeneratedComponentTemplateFiles);
+        expect(getGeneratedComponentFiles(tempDir, uuid).sort()).toEqual(getExpectedGeneratedComponentTemplateFiles(uuid).sort());
     });
     test("should be able to run the build", () => {
         expect(

--- a/packages/fast-cli/src/components/text-area/template/component.template.ts
+++ b/packages/fast-cli/src/components/text-area/template/component.template.ts
@@ -1,12 +1,12 @@
 import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string => `
-import { TextArea, textAreaTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
+import { TextArea as FoundationTextArea, textAreaTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
 import type { ViewTemplate } from "@microsoft/fast-element";
 
 /**
  * The template for ${config.className} component.
  * @public
  */
-export const template: FoundationElementTemplate<ViewTemplate<TextArea>> = textAreaTemplate;
+export const template: FoundationElementTemplate<ViewTemplate<FoundationTextArea>> = textAreaTemplate;
 `;

--- a/packages/fast-cli/src/components/text-area/template/component.ts
+++ b/packages/fast-cli/src/components/text-area/template/component.ts
@@ -2,7 +2,7 @@ import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string =>
 `import { attr } from "@microsoft/fast-element";
-import { TextArea } from "@microsoft/fast-foundation";
+import { TextArea as FoundationTextArea } from "@microsoft/fast-foundation";
 
 /**
  * Text area appearances
@@ -13,7 +13,7 @@ export type TextAreaAppearance = "filled" | "outline";
 /**
  * A class derived from the TextArea foundation component
  */
-export class ${config.className} extends TextArea {
+export class ${config.className} extends FoundationTextArea {
     /**
      * The appearance of the element.
      *

--- a/packages/fast-cli/src/components/text-field/template.pw.spec.ts
+++ b/packages/fast-cli/src/components/text-field/template.pw.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { execSync } from "child_process";
 import {
-    expectedGeneratedComponentTemplateFiles,
+    getExpectedGeneratedComponentTemplateFiles,
     setupComponent,
     teardown,
     getGeneratedComponentFiles,
@@ -21,7 +21,7 @@ test.describe(`CLI add-foundation-component ${uuid}`, () => {
         teardown(tempDir, tempComponentDir);
     });
     test("should copy files from the template", () => {
-        expect(getGeneratedComponentFiles(tempDir)).toEqual(expectedGeneratedComponentTemplateFiles);
+        expect(getGeneratedComponentFiles(tempDir, uuid).sort()).toEqual(getExpectedGeneratedComponentTemplateFiles(uuid).sort());
     });
     test("should be able to run the build", () => {
         expect(

--- a/packages/fast-cli/src/components/text-field/template/component.template.ts
+++ b/packages/fast-cli/src/components/text-field/template/component.template.ts
@@ -1,12 +1,12 @@
 import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string => `
-import { TextField, textFieldTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
+import { TextField as FoundationTextField, textFieldTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
 import type { ViewTemplate } from "@microsoft/fast-element";
 
 /**
  * The template for ${config.className} component.
  * @public
  */
-export const template: FoundationElementTemplate<ViewTemplate<TextField>> = textFieldTemplate;
+export const template: FoundationElementTemplate<ViewTemplate<FoundationTextField>> = textFieldTemplate;
 `;

--- a/packages/fast-cli/src/components/text-field/template/component.ts
+++ b/packages/fast-cli/src/components/text-field/template/component.ts
@@ -2,7 +2,7 @@ import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string =>
 `import { attr } from "@microsoft/fast-element";
-import { TextField } from "@microsoft/fast-foundation";
+import { TextField as FoundationTextField } from "@microsoft/fast-foundation";
 
 /**
  * Text field appearances
@@ -13,7 +13,7 @@ export type TextFieldAppearance = "filled" | "outline";
 /**
  * A class derived from the TextField foundation component
  */
-export class ${config.className} extends TextField {
+export class ${config.className} extends FoundationTextField {
     /**
      * The appearance of the element.
      *

--- a/packages/fast-cli/src/components/toolbar/template.pw.spec.ts
+++ b/packages/fast-cli/src/components/toolbar/template.pw.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { execSync } from "child_process";
 import {
-    expectedGeneratedComponentTemplateFiles,
+    getExpectedGeneratedComponentTemplateFiles,
     setupComponent,
     teardown,
     getGeneratedComponentFiles,
@@ -21,7 +21,7 @@ test.describe(`CLI add-foundation-component ${uuid}`, () => {
         teardown(tempDir, tempComponentDir);
     });
     test("should copy files from the template", () => {
-        expect(getGeneratedComponentFiles(tempDir)).toEqual(expectedGeneratedComponentTemplateFiles);
+        expect(getGeneratedComponentFiles(tempDir, uuid).sort()).toEqual(getExpectedGeneratedComponentTemplateFiles(uuid).sort());
     });
     test("should be able to run the build", () => {
         expect(

--- a/packages/fast-cli/src/components/toolbar/template/component.template.ts
+++ b/packages/fast-cli/src/components/toolbar/template/component.template.ts
@@ -1,12 +1,12 @@
 import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string => `
-import { Toolbar, toolbarTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
+import { Toolbar as FoundationToolbar, toolbarTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
 import type { ViewTemplate } from "@microsoft/fast-element";
 
 /**
  * The template for ${config.className} component.
  * @public
  */
-export const template: FoundationElementTemplate<ViewTemplate<Toolbar>> = toolbarTemplate;
+export const template: FoundationElementTemplate<ViewTemplate<FoundationToolbar>> = toolbarTemplate;
 `;

--- a/packages/fast-cli/src/components/toolbar/template/component.ts
+++ b/packages/fast-cli/src/components/toolbar/template/component.ts
@@ -1,14 +1,14 @@
 import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string =>
-`import { composedParent, Toolbar } from "@microsoft/fast-foundation";
+`import { composedParent, Toolbar as FoundationToolbar } from "@microsoft/fast-foundation";
 import type { Swatch } from "@microsoft/adaptive-ui/dist/dts/color/swatch.d.js"
 import { fillColor, neutralFillLayerRecipe } from "@microsoft/adaptive-ui";
 
 /**
  * A class derived from the Toolbar foundation component
  */
-export class ${config.className} extends Toolbar {
+export class ${config.className} extends FoundationToolbar {
     connectedCallback() {
         super.connectedCallback();
 

--- a/packages/fast-cli/src/components/tooltip/template.pw.spec.ts
+++ b/packages/fast-cli/src/components/tooltip/template.pw.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { execSync } from "child_process";
 import {
-    expectedGeneratedComponentTemplateFiles,
+    getExpectedGeneratedComponentTemplateFiles,
     setupComponent,
     teardown,
     getGeneratedComponentFiles,
@@ -21,7 +21,7 @@ test.describe(`CLI add-foundation-component ${uuid}`, () => {
         teardown(tempDir, tempComponentDir);
     });
     test("should copy files from the template", () => {
-        expect(getGeneratedComponentFiles(tempDir)).toEqual(expectedGeneratedComponentTemplateFiles);
+        expect(getGeneratedComponentFiles(tempDir, uuid).sort()).toEqual(getExpectedGeneratedComponentTemplateFiles(uuid).sort());
     });
     test("should be able to run the build", () => {
         expect(

--- a/packages/fast-cli/src/components/tooltip/template/component.template.ts
+++ b/packages/fast-cli/src/components/tooltip/template/component.template.ts
@@ -1,12 +1,12 @@
 import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string => `
-import { Tooltip, tooltipTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
+import { Tooltip as FoundationTooltip, tooltipTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
 import type { ViewTemplate } from "@microsoft/fast-element";
 
 /**
  * The template for ${config.className} component.
  * @public
  */
-export const template: FoundationElementTemplate<ViewTemplate<Tooltip>> = tooltipTemplate;
+export const template: FoundationElementTemplate<ViewTemplate<FoundationTooltip>> = tooltipTemplate;
 `;

--- a/packages/fast-cli/src/components/tooltip/template/component.ts
+++ b/packages/fast-cli/src/components/tooltip/template/component.ts
@@ -1,9 +1,9 @@
 import type { ComponentTemplateConfig } from "../../../utilities/template";
 
 export default (config: ComponentTemplateConfig): string =>
-`import { Tooltip } from "@microsoft/fast-foundation";
+`import { Tooltip as FoundationTooltip } from "@microsoft/fast-foundation";
 
 /**
  * A class derived from the Tooltip foundation component
  */
-export class ${config.className} extends Tooltip {};`
+export class ${config.className} extends FoundationTooltip {};`

--- a/packages/fast-cli/src/test/helpers.ts
+++ b/packages/fast-cli/src/test/helpers.ts
@@ -33,7 +33,7 @@ export function setup(tempDir: string, tempComponentDir: string): void {
         ...availableTemplates.reduce((prevValue, currValue: string) => {
             return {
                 ...prevValue,
-                [`fast:add-foundation-component:${currValue}`]: `fast add-foundation-component -n test-component -t ${currValue}`
+                [`fast:add-foundation-component:${currValue}`]: `fast add-foundation-component -n ${currValue} -t ${currValue}`
             }
         }, {}),
     };
@@ -52,12 +52,12 @@ export function teardown(tempDir: string, tempComponentDir: string): void {
     fs.removeSync(tempComponentDir);
 }
 
-export function getGeneratedComponentFiles(tempDir: string): Array<string> {
+export function getGeneratedComponentFiles(tempDir: string, componentName: string): Array<string> {
     const files: Array<string> = [];
 
     function testGeneratedFiles(folderName: string): void {
-        const tempDirContents = fs.readdirSync(path.resolve(tempDir, "src/components/test-component", folderName));
-        const tempDirContentsWithFileTypes = fs.readdirSync(path.resolve(tempDir, "src/components/test-component", folderName), {
+        const tempDirContents = fs.readdirSync(path.resolve(tempDir, `src/components/${componentName}`, folderName));
+        const tempDirContentsWithFileTypes = fs.readdirSync(path.resolve(tempDir, `src/components/${componentName}`, folderName), {
             withFileTypes: true
         });
 
@@ -79,14 +79,14 @@ export function getGeneratedComponentFiles(tempDir: string): Array<string> {
     return files;
 }
 
-export const expectedGeneratedComponentTemplateFiles = [
+export const getExpectedGeneratedComponentTemplateFiles = (componentName: string): Array<string> => [
     "README.md",
+    `${componentName}.definition.ts`,
+    `${componentName}.pw.spec.ts`,
+    `${componentName}.stories.ts`,
+    `${componentName}.styles.ts`,
+    `${componentName}.template.ts`,
+    `${componentName}.ts`,
     "define.ts",
     "fixtures/base.html",
-    "test-component.definition.ts",
-    "test-component.pw.spec.ts",
-    "test-component.stories.ts",
-    "test-component.styles.ts",
-    "test-component.template.ts",
-    "test-component.ts"
 ];


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
These changes are stabilizing changes and perform the following:
- Ensure names are not collided if the user changes the same name imported from `@microsoft/fast-foundation`
- Adds a definition suffix to prevent cases where components such as "switch" which are javascript keywords are not accidentally used as variables
- Updates all tests to use the names of the foundation component templates

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.
-->
These changes are more stabilizing than additional functionality, though the definitions are changing so the user will have to use `switchDefinition()` inside the `DesignSystem`s `register` method for the sake of naming safety.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.