### PR TITLE
Users/janechu/convert templates to template literals

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -37,7 +37,6 @@ module.exports = {
                 variableDeclaration: false,
             },
         ],
-        "@typescript-eslint/explicit-function-return-type": "error",
         "@typescript-eslint/camelcase": "off",
         "@typescript-eslint/naming-convention": [
             "error",

--- a/packages/fast-cli/src/cli.template.spec.ts
+++ b/packages/fast-cli/src/cli.template.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "@playwright/test";
+import { tsTemplate } from "./cli.template.js";
+
+test.describe("template", () => {
+    test("tsTemplate", () => {
+        const renderable1 = tsTemplate`foo${c => c.tagName}`;
+        const renderable2 = tsTemplate`${c => c.tagName}foo`;
+        const renderable3 = tsTemplate`foo${c => c.tagName}bat`;
+
+        expect(renderable1.render({
+            tagName: "bar",
+            className: "bat",
+            definitionName: "baz",
+            componentPrefix: "test"
+        })).toEqual("foobar");
+        expect(renderable2.render({
+            tagName: "bar",
+            className: "bat",
+            definitionName: "baz",
+            componentPrefix: "test"
+        })).toEqual("barfoo");
+        expect(renderable3.render({
+            tagName: "bar",
+            className: "bat",
+            definitionName: "baz",
+            componentPrefix: "test"
+        })).toEqual("foobarbat");
+    });
+});

--- a/packages/fast-cli/src/cli.template.spec.ts
+++ b/packages/fast-cli/src/cli.template.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { tsTemplate } from "./cli.template.js";
 
-test.describe("template", () => {
+test.describe.only("template", () => {
     test("tsTemplate", () => {
         const renderable1 = tsTemplate`foo${c => c.tagName}`;
         const renderable2 = tsTemplate`${c => c.tagName}foo`;

--- a/packages/fast-cli/src/cli.template.ts
+++ b/packages/fast-cli/src/cli.template.ts
@@ -1,0 +1,50 @@
+import type { CliConfigCallback, ComponentTemplateConfig } from "./utilities/template.js";
+
+type IterableTemplateContent = Array<string | CliConfigCallback>;
+
+/**
+ * The return class for the ts template literal tag in which the config
+ * is passed.
+ */
+export class RenderableTemplate {
+    private contents: IterableTemplateContent;
+
+    constructor(contents: IterableTemplateContent) {
+        this.contents = contents;
+    }
+
+    /**
+     * The render method for the string output of the template file
+     */
+    render(config: ComponentTemplateConfig): string {
+        return this.contents.reduce<string>((previousValue, currentValue): string => {
+            if (typeof currentValue === "string") {
+                previousValue += currentValue;
+            } else {
+                previousValue += currentValue(config);
+            }
+
+            return previousValue;
+        }, "");
+    }
+}
+
+/**
+ * A template literal tag for typescript component templates
+ */
+function tagTemplate(
+    strings: TemplateStringsArray,
+    ...config: IterableTemplateContent
+): RenderableTemplate {
+    const contents: IterableTemplateContent = [];
+
+    strings.forEach((stringItem: string, index: number) => {
+        contents.push(stringItem, config[index] || "");
+    });
+
+    return new RenderableTemplate(contents);
+}
+
+export const tsTemplate = tagTemplate;
+export const htmlTemplate = tagTemplate;
+export const mdTemplate = tagTemplate;

--- a/packages/fast-cli/src/cli.ts
+++ b/packages/fast-cli/src/cli.ts
@@ -14,6 +14,7 @@ import { addComponentPrompts, addDesignSystemPrompts, addFoundationComponentProm
 import { __dirname, ascii, cliPath, defaultTemplatePath, folderMatches, templateFolderName } from "./cli.globals.js";
 import { stringModifier, toCamelCase, toPascalCase } from "./cli.utilities.js";
 import designSystemTemplate from "./templates/design-system.js";
+import type { RenderableTemplate } from "./cli.template.js";
 
 const program = new commander.Command();
 
@@ -358,12 +359,12 @@ export async function getTemplateFiles(fastConfig: FastConfig, pathToTemplatePac
         files.push({
             name: basename,
             directory: path.resolve(rootDir, fastConfig.componentPath, name, fileDir),
-            contents: template({
+            contents: (template as RenderableTemplate).render({
                 tagName: name,
                 className: toPascalCase(name),
                 definitionName: `${toCamelCase(name)}Definition`,
                 componentPrefix: fastConfig.componentPrefix,
-            } as ComponentTemplateConfig)
+            })
         });
     }
 
@@ -614,3 +615,4 @@ program.command("add-foundation-component")
 program.parse(process.argv);
 
 export { ComponentTemplateConfig };
+export { htmlTemplate, mdTemplate, tsTemplate } from "./cli.template.js";

--- a/packages/fast-cli/src/components/accordion/template.pw.spec.ts
+++ b/packages/fast-cli/src/components/accordion/template.pw.spec.ts
@@ -13,7 +13,7 @@ const uuid: string = "accordion";
 const tempDir: string = getTempDir(uuid);
 const tempComponentDir: string = getTempComponentDir(uuid);
 
-test.describe(`CLI add-foundation-component ${uuid}`, () => {
+test.describe.only(`CLI add-foundation-component ${uuid}`, () => {
     test.beforeAll(() => {
         setupComponent(uuid, tempDir, tempComponentDir);
     });

--- a/packages/fast-cli/src/components/accordion/template/README.ts
+++ b/packages/fast-cli/src/components/accordion/template/README.ts
@@ -1,8 +1,7 @@
-import type { ComponentTemplateConfig } from "../../../utilities/template";
+import { mdTemplate } from "../../../cli.js";
 
-export default (config: ComponentTemplateConfig): string => `
-# ${config.className}
+export default mdTemplate`# ${c => c.className}
 
-${config.tagName} is a web component implementation of an [Accordion](https://w3c.github.io/aria-practices/#accordion).
+${c => c.tagName} is a web component implementation of an [Accordion](https://w3c.github.io/aria-practices/#accordion).
 
 For more information on the building blocks used to create this component, please refer to https://www.fast.design/docs/components/accordion`;

--- a/packages/fast-cli/src/components/accordion/template/component.definition.ts
+++ b/packages/fast-cli/src/components/accordion/template/component.definition.ts
@@ -1,11 +1,10 @@
-import type { ComponentTemplateConfig } from "../../../utilities/template";
+import { tsTemplate } from "../../../cli.js";
 
-export default (config: ComponentTemplateConfig): string => 
-`import { template } from "./${config.tagName}.template.js";
-import { styles } from "./${config.tagName}.styles.js";
+export default tsTemplate`import { template } from "./${c => c.tagName}.template.js";
+import { styles } from "./${c => c.tagName}.styles.js";
 
 export const definition = {
-    baseName: "${config.tagName}",
+    baseName: "${c => c.tagName}",
     template,
     styles,
 };`;

--- a/packages/fast-cli/src/components/accordion/template/component.pw.spec.ts
+++ b/packages/fast-cli/src/components/accordion/template/component.pw.spec.ts
@@ -1,11 +1,10 @@
-import type { ComponentTemplateConfig } from "../../../utilities/template";
+import { tsTemplate } from "../../../cli.js";
 
-export default (config: ComponentTemplateConfig): string => `
-import { expect, test } from "@playwright/test";
+export default tsTemplate`import { expect, test } from "@playwright/test";
 import { fixtureURL } from "@microsoft/fast-cli/dist/esm/utilities/playwright.js";
 
-test.describe("${config.tagName}", () => {
-    const fixture = fixtureURL("${config.tagName}");
+test.describe("${c => c.tagName}", () => {
+    const fixture = fixtureURL("${c => c.tagName}");
 
     test.beforeEach(async ({ page }) => {
         await page.goto(fixture);
@@ -17,7 +16,7 @@ test.describe("${config.tagName}", () => {
         expect(pageUrl).toBe(\`http://localhost:3000/\${fixture}\`);
     });
     test("should contain the component in the URL", async ({ page }) => {
-        const element = page.locator("${config.tagName}");
+        const element = page.locator("${c => c.tagName}");
 
         await expect(element).not.toBeNull();
     });

--- a/packages/fast-cli/src/components/accordion/template/component.stories.ts
+++ b/packages/fast-cli/src/components/accordion/template/component.stories.ts
@@ -1,19 +1,18 @@
-import type { ComponentTemplateConfig } from "../../../utilities/template";
+import { tsTemplate } from "../../../cli.js";
 
-export default (config: ComponentTemplateConfig): string => `
-import Template from "./fixtures/base.html";
+export default tsTemplate`import Template from "./fixtures/base.html";
 import { DesignSystem } from "@microsoft/fast-foundation";
-import { ${config.definitionName} } from "./define.js";
+import { ${c => c.definitionName} } from "./define.js";
 
 DesignSystem.getOrCreate().withPrefix(
-    "${config.componentPrefix}"
+    "${c => c.componentPrefix}"
 ).register(
-    ${config.definitionName}()
+    ${c => c.definitionName}()
 );
 
 export default {
-    title: "${config.tagName}",
+    title: "${c => c.tagName}",
 };
 
-export const ${config.className}: () => "*.html" = () => Template;
+export const ${c => c.className}: () => "*.html" = () => Template;
 `;

--- a/packages/fast-cli/src/components/accordion/template/component.styles.ts
+++ b/packages/fast-cli/src/components/accordion/template/component.styles.ts
@@ -1,7 +1,6 @@
-import type { ComponentTemplateConfig } from "../../../utilities/template";
+import { tsTemplate } from "../../../cli.js";
 
-export default (config: ComponentTemplateConfig): string =>
-`import { css, ElementStyles } from "@microsoft/fast-element";
+export default tsTemplate`import { css, ElementStyles } from "@microsoft/fast-element";
 import {
     display,
     FoundationElementTemplate
@@ -13,7 +12,7 @@ import {
 } from "@microsoft/adaptive-ui";
 
 /**
- * Styles for ${config.className}
+ * Styles for ${c => c.className}
  * @public
  */
 export const styles: FoundationElementTemplate<ElementStyles> = (

--- a/packages/fast-cli/src/components/accordion/template/component.template.ts
+++ b/packages/fast-cli/src/components/accordion/template/component.template.ts
@@ -1,11 +1,10 @@
-import type { ComponentTemplateConfig } from "../../../utilities/template";
+import { tsTemplate } from "../../../cli.js";
 
-export default (config: ComponentTemplateConfig): string => `
-import { Accordion as FoundationAccordion, accordionTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
+export default tsTemplate`import { Accordion as FoundationAccordion, accordionTemplate, FoundationElementTemplate } from "@microsoft/fast-foundation";
 import type { ViewTemplate } from "@microsoft/fast-element";
 
 /**
- * The template for ${config.className} component.
+ * The template for ${c => c.className} component.
  * @public
  */
 export const template: FoundationElementTemplate<ViewTemplate<FoundationAccordion>> = accordionTemplate;

--- a/packages/fast-cli/src/components/accordion/template/component.ts
+++ b/packages/fast-cli/src/components/accordion/template/component.ts
@@ -1,10 +1,9 @@
-import type { ComponentTemplateConfig } from "../../../utilities/template";
+import { tsTemplate } from "../../../cli.js";
 
-export default (config: ComponentTemplateConfig): string =>
-`import { attr } from "@microsoft/fast-element";
+export default tsTemplate`import { attr } from "@microsoft/fast-element";
 import { Accordion as FoundationAccordion } from "@microsoft/fast-foundation";
 
 /**
  * A class derived from the Accordion foundation component
  */
-export class ${config.className} extends FoundationAccordion {};`
+export class ${c => c.className} extends FoundationAccordion {};`

--- a/packages/fast-cli/src/components/accordion/template/define.ts
+++ b/packages/fast-cli/src/components/accordion/template/define.ts
@@ -1,7 +1,6 @@
-import type { ComponentTemplateConfig } from "../../../utilities/template";
+import { tsTemplate } from "../../../cli.js";
 
-export default (config: ComponentTemplateConfig): string =>
-`import { ${config.className} } from "./${config.tagName}.js";
-import { definition } from "./${config.tagName}.definition.js";
+export default tsTemplate`import { ${c => c.className} } from "./${c => c.tagName}.js";
+import { definition } from "./${c => c.tagName}.definition.js";
 
-export const ${config.definitionName} = ${config.className}.compose(definition);`;
+export const ${c => c.definitionName} = ${c => c.className}.compose(definition);`;

--- a/packages/fast-cli/src/components/accordion/template/fixture.ts
+++ b/packages/fast-cli/src/components/accordion/template/fixture.ts
@@ -1,17 +1,16 @@
-import type { ComponentTemplateConfig } from "../../../utilities/template";
+import { htmlTemplate } from "../../../cli.js";
 
-export default (config: ComponentTemplateConfig): string =>
-`<style>
-    ${config.tagName}-item.disabled::part(button) {
+export default htmlTemplate`<style>
+    ${c => c.tagName}-item.disabled::part(button) {
         pointer-events: none;
     }
 </style>
 
-<h1>${config.className}Item</h1>
+<h1>${c => c.className}Item</h1>
 
 <h2>Default</h2>
-<${config.componentPrefix}-${config.tagName}>
-    <${config.componentPrefix}-${config.tagName}-item expanded>
+<${c => c.componentPrefix}-${c => c.tagName}>
+    <${c => c.componentPrefix}-${c => c.tagName}-item expanded>
         <div slot="start">
             <button>1</button>
         </div>
@@ -20,21 +19,21 @@ export default (config: ComponentTemplateConfig): string =>
         </div>
         <span slot="heading">Panel one</span>
         Panel one content
-    </${config.componentPrefix}-${config.tagName}-item>
-    <${config.componentPrefix}-${config.tagName}-item expanded>
+    </${c => c.componentPrefix}-${c => c.tagName}-item>
+    <${c => c.componentPrefix}-${c => c.tagName}-item expanded>
         <span slot="heading">Panel two</span>
         <fast-button tabindex="0">Button</fast-button>
         <fast-button tabindex="0">Button</fast-button>
-    </${config.componentPrefix}-${config.tagName}-item>
-    <${config.componentPrefix}-${config.tagName}-item expanded>
+    </${c => c.componentPrefix}-${c => c.tagName}-item>
+    <${c => c.componentPrefix}-${c => c.tagName}-item expanded>
         <span slot="heading">Panel three</span>
         Panel three content
-    </${config.componentPrefix}-${config.tagName}-item>
-</${config.componentPrefix}-${config.tagName}>
+    </${c => c.componentPrefix}-${c => c.tagName}-item>
+</${c => c.componentPrefix}-${c => c.tagName}>
 
 <h2>Single expand</h2>
-<${config.componentPrefix}-${config.tagName} expand-mode="single">
-    <${config.componentPrefix}-${config.tagName}-item>
+<${c => c.componentPrefix}-${c => c.tagName} expand-mode="single">
+    <${c => c.componentPrefix}-${c => c.tagName}-item>
         <div slot="start">
             <button>1</button>
         </div>
@@ -43,20 +42,20 @@ export default (config: ComponentTemplateConfig): string =>
         </div>
         <span slot="heading">Panel one</span>
         Panel one content
-    </${config.componentPrefix}-${config.tagName}-item>
-    <${config.componentPrefix}-${config.tagName}-item class="disabled">
+    </${c => c.componentPrefix}-${c => c.tagName}-item>
+    <${c => c.componentPrefix}-${c => c.tagName}-item class="disabled">
         <span slot="heading">Panel Two</span>
         Panel two content
-    </${config.componentPrefix}-${config.tagName}-item>
-    <${config.componentPrefix}-${config.tagName}-item>
+    </${c => c.componentPrefix}-${c => c.tagName}-item>
+    <${c => c.componentPrefix}-${c => c.tagName}-item>
         <span slot="heading">Panel three</span>
         Panel three content
-    </${config.componentPrefix}-${config.tagName}-item>
-</${config.componentPrefix}-${config.tagName}>
+    </${c => c.componentPrefix}-${c => c.tagName}-item>
+</${c => c.componentPrefix}-${c => c.tagName}>
 
 <h2>With disabled item</h2>
-<${config.componentPrefix}-${config.tagName}>
-    <${config.componentPrefix}-${config.tagName}-item>
+<${c => c.componentPrefix}-${c => c.tagName}>
+    <${c => c.componentPrefix}-${c => c.tagName}-item>
         <div slot="start">
             <button>1</button>
         </div>
@@ -65,8 +64,8 @@ export default (config: ComponentTemplateConfig): string =>
         </div>
         <span slot="heading">Panel two</span>
         Panel one content
-    </${config.componentPrefix}-${config.tagName}-item>
-    <${config.componentPrefix}-${config.tagName}-item class="disabled">
+    </${c => c.componentPrefix}-${c => c.tagName}-item>
+    <${c => c.componentPrefix}-${c => c.tagName}-item class="disabled">
         <div slot="start">
             <button>1</button>
         </div>
@@ -75,8 +74,8 @@ export default (config: ComponentTemplateConfig): string =>
         </div>
         <span slot="heading">Disabled</span>
         Disabled content
-    </${config.componentPrefix}-${config.tagName}-item>
-    <${config.componentPrefix}-${config.tagName}-item expanded>
+    </${c => c.componentPrefix}-${c => c.tagName}-item>
+    <${c => c.componentPrefix}-${c => c.tagName}-item expanded>
         <div slot="start">
             <button>1</button>
         </div>
@@ -85,12 +84,12 @@ export default (config: ComponentTemplateConfig): string =>
         </div>
         <span slot="heading">Panel three</span>
         Panel three content
-    </${config.componentPrefix}-${config.tagName}-item>
-</${config.componentPrefix}-${config.tagName}>
+    </${c => c.componentPrefix}-${c => c.tagName}-item>
+</${c => c.componentPrefix}-${c => c.tagName}>
 
 <h2>Custom expanded and collapsed icons</h2>
-<${config.componentPrefix}-${config.tagName}>
-    <${config.componentPrefix}-${config.tagName}-item expanded>
+<${c => c.componentPrefix}-${c => c.tagName}>
+    <${c => c.componentPrefix}-${c => c.tagName}-item expanded>
         <span slot="heading">Panel one</span>
         <svg
             slot="collapsed-icon"
@@ -115,5 +114,5 @@ export default (config: ComponentTemplateConfig): string =>
             />
         </svg>
         Panel one content
-    </${config.componentPrefix}-${config.tagName}-item>
-</${config.componentPrefix}-${config.tagName}>`;
+    </${c => c.componentPrefix}-${c => c.tagName}-item>
+</${c => c.componentPrefix}-${c => c.tagName}>`;

--- a/packages/fast-cli/src/utilities/template.ts
+++ b/packages/fast-cli/src/utilities/template.ts
@@ -24,3 +24,10 @@ export interface ComponentTemplateConfig {
      */
     componentPrefix: string;
 }
+
+/**
+ * Template callback for ts templates
+ */
+export type CliConfigCallback = (
+    config: ComponentTemplateConfig
+) => string;


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This pull request adds the exports `tsTemplate`, `htmlTemplate`, and `mdTemplate` for the purposes of ease of use as this is closer to the mechanism used by FAST Element, and for a future code highlighting case.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.