### PR TITLE
Fixed async issue when installing all components

### DIFF
--- a/packages/fast-cli/src/cli.spec.ts
+++ b/packages/fast-cli/src/cli.spec.ts
@@ -265,8 +265,7 @@ test.describe("CLI", () => {
             ).not.toThrow();
         });
     });
-    // Skip these tests while adaptive UI is sym-linked from a private package
-    test.describe.skip("add-foundation-component --all", () => {
+    test.describe("add-foundation-component --all", () => {
         test.beforeAll(() => {
             setup(tempDir, tempComponentDir, uuid);
             execSync(`cd ${tempDir} && npm run fast:init`);


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This change fixes an issue where `npm install` for running the `add-foundation-component` with the `--all` flag would error as these were not running async. It also enables the tests that were failing.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.