### PR TITLE
fix(docs): add-a-component command argument typo fix

### DIFF
--- a/website/docs/add-a-component.md
+++ b/website/docs/add-a-component.md
@@ -14,4 +14,4 @@ Argument | Shorthand | Description | Required | Default | Options
 `--name <name>` | `-n <name>` | The name of the component to be added | Yes | |
 `--template <path/to/template>` | `-t <path/to/template>` | Template which includes all of the required component template files | No | | `<path/to/template>`
 
-A template npm package or local package can be specified or a selection of pre-congured named templates can be used.
+A template `npm` package or local package can be specified. Or a selection of pre-configured named templates can be used.

--- a/website/docs/add-a-component.md
+++ b/website/docs/add-a-component.md
@@ -14,4 +14,4 @@ Argument | Shorthand | Description | Required | Default | Options
 `--name <name>` | `-n <name>` | The name of the component to be added | Yes | |
 `--template <path/to/template>` | `-t <path/to/template>` | Template which includes all of the required component template files | No | | `<path/to/template>`
 
-A template `npm` package or local package can be specified. Or a selection of pre-configured named templates can be used.
+A template `npm` package or local package can be specified, or a selection of pre-configured named templates can be used.


### PR DESCRIPTION
I updated the syntax of the sentence and fixed a typo assuming that what's meant is **pre-configured** not **pre-congured**.

# Pull Request

## 📖 Description

Docs update to fix typo in add-component page when explaining the arguments that should be supplied to the CLI command during component creation. 
<!--- Provide some background and a description of your work. -->

### 🎫 Issues
Not applicable
<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->

## 👩‍💻 Reviewer Notes
Not applicable
<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [*] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps
Not applicable
<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->