### PR TITLE
fix(docs): flipper reference link points to card

### DIFF
--- a/packages/fast-cli/src/components/flipper/template/README.ts
+++ b/packages/fast-cli/src/components/flipper/template/README.ts
@@ -3,4 +3,4 @@ import { mdTemplate } from "../../../cli.js";
 export default mdTemplate`# ${c => c.className}
 The flipper component is most often used to page through blocks of content or collections of UI elements.
 
-For more information on the building blocks used to create this component, please refer to https://www.fast.design/docs/components/card`;
+For more information on the building blocks used to create this component, please refer to https://www.fast.design/docs/components/flipper`;


### PR DESCRIPTION
I think that the reference link to "read more" should point to the flipper component not to the card component.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->
-  I have updated the project documentation to reflect my changes.
