### PR TITLE
Added migrate package for FAST CLI

### DIFF
--- a/change/@microsoft-eslint-plugin-fast-cli-migrate-cfc28589-7147-452e-a9af-f9747d8f64d1.json
+++ b/change/@microsoft-eslint-plugin-fast-cli-migrate-cfc28589-7147-452e-a9af-f9747d8f64d1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added migrate package for FAST CLI",
+  "packageName": "@microsoft/eslint-plugin-fast-cli-migrate",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2117,6 +2117,10 @@
       "resolved": "packages/create-fast-project",
       "link": true
     },
+    "node_modules/@microsoft/eslint-plugin-fast-cli-migrate": {
+      "resolved": "packages/eslint-plugin-fast-cli-migrate",
+      "link": true
+    },
     "node_modules/@microsoft/fast-cli": {
       "resolved": "packages/fast-cli",
       "link": true
@@ -21674,7 +21678,7 @@
     },
     "packages/cfp-template": {
       "name": "@microsoft/cfp-template",
-      "version": "1.0.0-alpha.2",
+      "version": "1.0.0-alpha.5",
       "license": "MIT",
       "dependencies": {
         "@microsoft/fast-element": "2.0.0-beta.3",
@@ -21725,11 +21729,11 @@
     },
     "packages/create-fast-project": {
       "name": "@microsoft/create-fast-project",
-      "version": "1.0.0-alpha.2",
+      "version": "1.0.0-alpha.5",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/cfp-template": "^1.0.0-alpha.2",
-        "@microsoft/fast-cli": "^1.0.0-alpha.2",
+        "@microsoft/cfp-template": "^1.0.0-alpha.5",
+        "@microsoft/fast-cli": "^1.0.0-alpha.5",
         "cross-spawn": "^7.0.3"
       },
       "bin": {
@@ -21740,9 +21744,13 @@
         "typescript": "^4.6.3"
       }
     },
+    "packages/eslint-plugin-fast-cli-migrate": {
+      "version": "1.0.0-alpha.5",
+      "license": "MIT"
+    },
     "packages/fast-cli": {
       "name": "@microsoft/fast-cli",
-      "version": "1.0.0-alpha.2",
+      "version": "1.0.0-alpha.5",
       "license": "MIT",
       "dependencies": {
         "commander": "^9.0.0",
@@ -23184,12 +23192,15 @@
     "@microsoft/create-fast-project": {
       "version": "file:packages/create-fast-project",
       "requires": {
-        "@microsoft/cfp-template": "*",
-        "@microsoft/fast-cli": "^1.0.0-alpha.2",
+        "@microsoft/cfp-template": "^1.0.0-alpha.5",
+        "@microsoft/fast-cli": "^1.0.0-alpha.5",
         "@types/node": "^17.0.21",
         "cross-spawn": "^7.0.3",
         "typescript": "^4.6.3"
       }
+    },
+    "@microsoft/eslint-plugin-fast-cli-migrate": {
+      "version": "file:packages/eslint-plugin-fast-cli-migrate"
     },
     "@microsoft/fast-cli": {
       "version": "file:packages/fast-cli",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "publish-ci": "beachball publish -y --access public --workspaces",
     "test:diff:error": "echo \"Untracked files exist, try running npm prepare to identify the culprit.\" && exit 1",
     "test:diff": "git update-index --refresh && git diff-index --quiet HEAD -- || npm run test:diff:error",
-    "test": "npm run build && npm run eslint && npm run test:cli && test:eslint",
+    "test": "npm run build && npm run eslint && npm run test:cli && npm run test:eslint",
     "test:eslint": "npx playwright test --config=./playwright.eslint.config.ts",
     "test:cli": "npx playwright test",
     "diff": "npm run prettier --workspaces --if-present && npm run test:diff"

--- a/package.json
+++ b/package.json
@@ -35,8 +35,9 @@
     "publish-ci": "beachball publish -y --access public --workspaces",
     "test:diff:error": "echo \"Untracked files exist, try running npm prepare to identify the culprit.\" && exit 1",
     "test:diff": "git update-index --refresh && git diff-index --quiet HEAD -- || npm run test:diff:error",
-    "test": "npm run test:cli",
-    "test:cli": "npm run build && npm run eslint && npx playwright test",
+    "test": "npm run build && npm run eslint && npm run test:cli && test:eslint",
+    "test:eslint": "npx playwright test --config=./playwright.eslint.config.ts",
+    "test:cli": "npx playwright test",
     "diff": "npm run prettier --workspaces --if-present && npm run test:diff"
   },
   "husky": {

--- a/packages/eslint-plugin-fast-cli-migrate/.eslintrc.cjs
+++ b/packages/eslint-plugin-fast-cli-migrate/.eslintrc.cjs
@@ -1,0 +1,13 @@
+module.exports = {
+    rules: {
+        "import/extensions": ["error", "never"],
+    },
+    overrides: [
+        {
+            files: ["**/tests/files/*.ts"],
+            rules: {
+                "import/extensions": ["error", "always"],
+            }
+        }
+    ]
+};

--- a/packages/eslint-plugin-fast-cli-migrate/.npmignore
+++ b/packages/eslint-plugin-fast-cli-migrate/.npmignore
@@ -1,0 +1,2 @@
+src
+tests

--- a/packages/eslint-plugin-fast-cli-migrate/CONTRIBUTING.md
+++ b/packages/eslint-plugin-fast-cli-migrate/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing
+
+## Rules
+
+Rules are the foundation of the ESLint plugin ecosystem, they contain the logic that will be applied when the plugin is used.
+
+### Creating a new rule
+
+When creating a new rule, the following files should be added:
+
+```
+src/
+└─ rules
+   └─ <my-rule-name>.ts
+   └─ <my-rule-name>.md
+tests/
+└─ files
+   └─ <my-rule-name>.invalid.ts
+   └─ <my-rule-name>.valid.ts
+```
+
+The `invalid` and `valid` test files should contain content that should be considered valid or invalid.
+
+To determine the logic necessary for a rule, use the https://astexplorer.net/, the sample code will be in the top left that will be linted, the plugin code you are creating will be in the bottom left, in the top right you will see what information is available to you for calling various methods, and in the bottom right you will see the error/warning etc., messages appear around your code.
+
+**Other changes**
+- Ensure the rule is added in the `src/index.ts`
+- Ensure the rule has a `src/rules/<version-matrix>-<rule-name>.md` file and this file is a URL in the rules `meta` object
+- Ensure the rule has been added to the tested rule list in `src/tests/rules/rules.spec.ts`
+- Ensure the rule is added to its dependency matrix documentation in `./README.md`
+- Ensure the rule is added to its dependency matrix in `./src/configs/<version-matrix>.ts`

--- a/packages/eslint-plugin-fast-cli-migrate/README.md
+++ b/packages/eslint-plugin-fast-cli-migrate/README.md
@@ -1,0 +1,40 @@
+# FAST CLI migrate ESLint Plugin
+
+This package's primary use is for use in the `@microsoft/fast-cli` package `migrate` command, you may not want to use it directly. The rules are based on versioning based on the CLI configuration file.
+
+If you'd like to leverage these rules individually as a path to migrate through the different versions available, check out our [version matrix](#version-matrix) for which rules to use.
+
+## Setup
+
+### First steps
+
+#### Install the package with NPM
+
+To add this package as a dependency with NPM, run `npm install @microsoft/eslint-plugin-fast-cli-migrate` in your project. To add this package as a development dependency, use the `--save-dev` flag.
+
+### Usage
+
+`.eslintrc.json`
+```json
+{
+    "extends": [
+        "plugin:@microsoft/fast-cli-migrate/<version-matrix>"
+    ],
+    "plugins": [
+        "@microsoft/fast-cli-migrate"
+    ]
+}
+```
+
+## Version matrix
+
+| Config Version | Dependencies | Rule Migration Documentation |
+|-|-|-|
+`1.0.0-alpha.1` | <ul><li>`@microsoft/adaptive-ui@1.0.0-alpha.4`</li><li>`@microsoft/fast-foundation@3.0.0-alpha.4`</li> | 
+<ul>
+<li>[class](https://github.com/microsoft/fast-cli/tree/main/packages/eslint-plugin-fast-cli-migrate/src/rules/1.0.0-alpha.1--class.ts)</li>
+</ul> |
+
+## Contributing
+
+Interested in contributing? Read our [contributing docs](https://github.com/microsoft/fast-cli/tree/main/packages/eslint-plugin-fast-cli-migrate/CONTRIBUTING.md) to get started.

--- a/packages/eslint-plugin-fast-cli-migrate/package.json
+++ b/packages/eslint-plugin-fast-cli-migrate/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@microsoft/eslint-plugin-fast-cli-migrate",
+  "version": "1.0.0-alpha.5",
+  "description": "An ESLint plugin with migration rules for FAST CLI",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "npm run build:cjs",
+    "build:cjs": "tsc -p ./tsconfig.cjs.json"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Microsoft/fast-cli.git"
+  },
+  "author": {
+    "name": "Microsoft",
+    "url": "https://discord.gg/FcSNfg4"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Microsoft/fast-cli/issues"
+  },
+  "homepage": "https://github.com/Microsoft/fast-cli#readme"
+}

--- a/packages/eslint-plugin-fast-cli-migrate/src/configs/1.0.0-alpha.1.ts
+++ b/packages/eslint-plugin-fast-cli-migrate/src/configs/1.0.0-alpha.1.ts
@@ -1,0 +1,5 @@
+export const v100alpha1 = {
+    rules: {
+        "1.0.0-alpha.1--class": "warn",
+    }
+}

--- a/packages/eslint-plugin-fast-cli-migrate/src/index.ts
+++ b/packages/eslint-plugin-fast-cli-migrate/src/index.ts
@@ -1,0 +1,10 @@
+import { v100alpha1 } from "./configs/1.0.0-alpha.1";
+import * as v100alpha1Class from "./rules/1.0.0-alpha.1--class";
+
+export const rules = {
+    "1.0.0-alpha.1--class": v100alpha1Class,
+}
+
+export const configs = {
+    "1.0.0-alpha.1": v100alpha1
+}

--- a/packages/eslint-plugin-fast-cli-migrate/src/rules/1.0.0-alpha.1--class.md
+++ b/packages/eslint-plugin-fast-cli-migrate/src/rules/1.0.0-alpha.1--class.md
@@ -1,0 +1,19 @@
+# fast-cli-migrate-1.0.0-alpha.1--class
+
+The class rule attempts to fix the references to `FoundationElement` from `@microsoft/fast-foundation` to `FASTElement` from `@microsoft/fast-element`.
+
+## Deprecated version
+
+```ts
+import { FoundationElement } from "@microsoft/fast-foundation";
+
+export class Foo extends FoundationElement { }
+```
+
+## After running ESLint with `fix` option
+
+```ts
+import { FASTElement } from "@microsoft/fast-element";
+
+export class Foo extends FASTElement { }
+```

--- a/packages/eslint-plugin-fast-cli-migrate/src/rules/1.0.0-alpha.1--class.ts
+++ b/packages/eslint-plugin-fast-cli-migrate/src/rules/1.0.0-alpha.1--class.ts
@@ -1,0 +1,89 @@
+import { Rule } from "eslint";
+import type {
+    Identifier,
+    ImportDeclaration,
+    ImportSpecifier,
+    ImportDefaultSpecifier,
+    ImportNamespaceSpecifier
+} from "estree";
+
+export const meta = {
+    type: "problem",
+    docs: {
+        description: "Update classes relying on FoundationElement to use FASTElement",
+        category: "Deprecated",
+        recommended: true,
+        url: "https://github.com/microsoft/fast-cli/tree/main/packages/eslint-plugin-fast-cli-migrate/src/rules/1.0.0-alpha.1--class.ts",
+    },
+    fixable: true,
+    schema: [],
+};
+
+function getFoundateElementImport(
+    specifiers: (ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier)[]
+) {
+    return specifiers.findIndex((specifier) => {
+        if (specifier.type === "ImportSpecifier") {
+            return specifier.imported.name === "FoundationElement";
+        }
+
+        return false;
+    });
+}
+
+function importsFoundationElement(node: ImportDeclaration & Rule.Node) {
+    if (node.source.value === "@microsoft/fast-foundation") {
+        const foundationElementImportIndex = getFoundateElementImport(node.specifiers);
+        const trailingComma = foundationElementImportIndex !== node.specifiers.length - 1;
+
+        return [node.specifiers[foundationElementImportIndex], trailingComma] || false;
+    }
+    return false;
+}
+
+function getFoundationElementImport(node) {
+    return importsFoundationElement(node);
+}
+
+export function create(context: Rule.RuleContext) {
+    return {
+        ImportDeclaration(node: ImportDeclaration & Rule.Node) {
+            const foundationElementImport = getFoundationElementImport(node);
+
+            if (foundationElementImport[0]) {
+                const rangeEnd = foundationElementImport[1]
+                    ? foundationElementImport[0].range[1] + 1
+                    : foundationElementImport[0].range[1];
+
+                context.report({
+                    node,
+                    message: "FoundationElement has been removed, import FASTElement instead",
+                    *fix(fixer) {
+                        yield fixer.removeRange([
+                            foundationElementImport[0].range[0],
+                            rangeEnd
+                        ]);
+                        yield fixer.insertTextAfter(
+                            node,
+                            `\nimport { FASTElement } from "@microsoft/fast-element";`
+                        );
+                    }
+                });
+            }
+        },
+        Identifier(node: Identifier & Rule.Node) {
+            if (
+                node.parent.type === "ClassDeclaration" &&
+                node.name === "FoundationElement"
+            ) {
+                context.report({
+                    node,
+                    message: "FoundationElement has been removed, use FASTElement instead",
+                    fix: (fixer) => {
+                        return fixer.replaceText(node, "FASTElement");
+                    }
+                });
+            }
+        }
+    };
+}

--- a/packages/eslint-plugin-fast-cli-migrate/src/rules/1.0.0-alpha.1--class.ts
+++ b/packages/eslint-plugin-fast-cli-migrate/src/rules/1.0.0-alpha.1--class.ts
@@ -2,9 +2,9 @@ import { Rule } from "eslint";
 import type {
     Identifier,
     ImportDeclaration,
-    ImportSpecifier,
     ImportDefaultSpecifier,
-    ImportNamespaceSpecifier
+    ImportNamespaceSpecifier,
+    ImportSpecifier
 } from "estree";
 
 export const meta = {
@@ -41,7 +41,7 @@ function importsFoundationElement(node: ImportDeclaration & Rule.Node) {
     return false;
 }
 
-function getFoundationElementImport(node) {
+function getFoundationElementImport(node: ImportDeclaration & Rule.Node) {
     return importsFoundationElement(node);
 }
 
@@ -58,7 +58,7 @@ export function create(context: Rule.RuleContext) {
                 context.report({
                     node,
                     message: "FoundationElement has been removed, import FASTElement instead",
-                    *fix(fixer) {
+                    *fix(fixer: Rule.RuleFixer) {
                         yield fixer.removeRange([
                             foundationElementImport[0].range[0],
                             rangeEnd

--- a/packages/eslint-plugin-fast-cli-migrate/src/tests/files/1.0.0-alpha.1--class.invalid.ts
+++ b/packages/eslint-plugin-fast-cli-migrate/src/tests/files/1.0.0-alpha.1--class.invalid.ts
@@ -1,0 +1,8 @@
+import { FoundationElement } from "@microsoft/fast-foundation";
+
+/**
+ * A Custom HTML Element.
+ *
+ * @public
+ */
+export class Foo extends FoundationElement { }

--- a/packages/eslint-plugin-fast-cli-migrate/src/tests/files/1.0.0-alpha.1--class.valid.ts
+++ b/packages/eslint-plugin-fast-cli-migrate/src/tests/files/1.0.0-alpha.1--class.valid.ts
@@ -1,0 +1,8 @@
+import { FASTElement } from "@microsoft/fast-element";
+
+/**
+ * A Custom HTML Element.
+ *
+ * @public
+ */
+export class Foo extends FASTElement { }

--- a/packages/eslint-plugin-fast-cli-migrate/src/tests/files/test.config.json
+++ b/packages/eslint-plugin-fast-cli-migrate/src/tests/files/test.config.json
@@ -1,0 +1,9 @@
+{
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+        "ecmaVersion": 2017
+    },
+    "env": {
+        "es6": true
+    }
+}

--- a/packages/eslint-plugin-fast-cli-migrate/src/tests/rules/rules.spec.ts
+++ b/packages/eslint-plugin-fast-cli-migrate/src/tests/rules/rules.spec.ts
@@ -1,0 +1,130 @@
+import path from "path";
+import { expect, test } from "@playwright/test";
+import { ESLint } from "eslint";
+import fs from "fs-extra";
+import * as eslintPlugin from "../../index";
+
+const testItems = [
+    {
+        rule: "1.0.0-alpha.1--class",
+        errorNumber: 2,
+        filePath: "foo",
+    },
+];
+
+function getFixedCode(invalidCode: string, fix) {
+    const originalContent = invalidCode.slice(
+        fix.range[0],
+        fix.range[1]
+    );
+    
+    return invalidCode.replace(originalContent, fix.text);
+}
+
+async function getFixedCodeFromMultipleFixes(invalidCode: string, messages, eslint, testItem) {
+    let fixedCode = invalidCode;
+
+    if (messages.length > 0) {
+        fixedCode = getFixedCode(fixedCode, messages[0].fix);
+
+        return await eslint
+            .lintText(fixedCode, {
+                filePath: testItem.filePath
+            })
+            .then((contents: any) => {
+                return getFixedCodeFromMultipleFixes(
+                    fixedCode,
+                    contents[0].messages,
+                    eslint,
+                    testItem,
+                );
+            });
+    } else {
+        return fixedCode;
+    }    
+}
+
+test.describe("Rules", () => {
+    testItems.forEach((testItem) => {
+        test.describe(testItem.rule, () => {
+            let eslint = new ESLint({
+                useEslintrc: false,
+                overrideConfigFile: "./src/tests/files/test.config.json",
+                rulePaths: ["./dist/rules"],
+                overrideConfig: {
+                    parserOptions: {
+                        fastConfig: {
+                            rootDir: "./src",
+                            componentPath: "./components",
+                            componentPrefix: "fast"
+                        }
+                    },
+                    rules: {
+                        [testItem.rule]: 2,
+                    },
+                },
+                cwd: path.dirname(require.resolve("@microsoft/eslint-plugin-fast-cli-migrate/package.json")),
+                plugins: { "@microsoft/eslint-plugin-fast-cli-migrate": eslintPlugin },
+            });
+            let invalidMessages: any;
+            let validMessages: any;
+            let invalidFileContents: string;
+            let validFileContents: string;
+        
+            test.beforeAll(() => {
+                invalidFileContents = fs.readFileSync(
+                    path.resolve(__dirname, `../files/${testItem.rule}.invalid.ts`),
+                    {
+                        encoding: "utf8"
+                    }
+                );
+                validFileContents = fs.readFileSync(
+                    path.resolve(__dirname, `../files/${testItem.rule}.valid.ts`),
+                    {
+                        encoding: "utf8"
+                    }
+                )
+
+                eslint
+                    .lintText(invalidFileContents, {
+                        filePath: testItem.filePath,
+                    })
+                    .then((contents: any) => {
+                        invalidMessages = contents[0].messages;
+                    });
+                eslint
+                    .lintText(validFileContents, {
+                        filePath: testItem.filePath
+                    })
+                    .then((contents: any) => {
+                        validMessages = contents[0].messages;
+                    });
+            });
+        
+            test("valid example does not contain error messages", () => {
+                expect(validMessages).toHaveLength(0);
+            });
+
+            test("invalid example does contain an error message and a fix message", () => {
+                expect(invalidMessages).toHaveLength(testItem.errorNumber);
+
+                for (const invalidMessage of invalidMessages) {
+                    expect(invalidMessage.ruleId).toEqual(testItem.rule);
+                }
+            });
+    
+            test("fix should convert invalid format to valid format", async () => {
+                // replace using the available fixes
+                const fixedCode = await getFixedCodeFromMultipleFixes(invalidFileContents, invalidMessages, eslint, testItem);
+                let messages: any;
+
+                // lint result
+                await eslint.lintText(fixedCode).then((contents: any) => {
+                    messages = contents[0].messages;
+                });
+                
+                expect(messages).toHaveLength(0);
+            });
+        });
+    });
+});

--- a/packages/eslint-plugin-fast-cli-migrate/tsconfig.cjs.json
+++ b/packages/eslint-plugin-fast-cli-migrate/tsconfig.cjs.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "outDir": "dist",
+        "lib": [
+            "DOM",
+            "ES6",
+        ],
+        "module": "CommonJS",
+        "esModuleInterop": true
+    },
+    "include": ["src/**/*.ts"],
+    "exclude": ["src/**/*.invalid.ts", "src/**/*.valid.ts", "src/**/*.spec.ts"]
+}

--- a/playwright.eslint.config.ts
+++ b/playwright.eslint.config.ts
@@ -1,0 +1,10 @@
+import type { PlaywrightTestConfig } from "@playwright/test";
+
+const config: PlaywrightTestConfig = {
+    testDir: "packages/eslint-plugin-fast-cli-migrate/src/tests/rules",
+    retries: process.env.CI ? 2 : 0,
+    testMatch: "**/?(*.)+(spec).+(ts)",
+    timeout: 60000
+};
+
+export default config;


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This change adds:
- The migrate ESLint package which contains fixes for deprecated code from previous versions
- A rule for migrating component class files

### 🎫 Issues

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->
Begins work on #41 

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.
-->
This new package will be leveraged by the FAST CLI, if the user chooses they can either attempt to fix, which will fire the fix command against their code and update it, or they can simply run it and get an output of all the issues detected.

The package will consume the `fast.config.json` file and therefore should know the locations of components and various other files needed for the migration to work.

You will see a mention of a "version matrix" in the `README.md` file. A single version will be stored in the `fast.config.json` and based on this version we will determine what versions of `@microsoft/fast-element` and `@microsoft/fast-foundation` the project should be on. This allows us to understand our upgrade migration path for both dependencies.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
- Continue adding migrate rules