### PR TITLE
Added the ability to list all foundation components

### DIFF
--- a/change/@microsoft-fast-cli-b9a34f3c-3c03-4c2b-80af-1d71c21616b5.json
+++ b/change/@microsoft-fast-cli-b9a34f3c-3c03-4c2b-80af-1d71c21616b5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Added the ability to list all foundation components",
+  "packageName": "@microsoft/fast-cli",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/fast-cli/src/cli.options.ts
+++ b/packages/fast-cli/src/cli.options.ts
@@ -79,6 +79,7 @@ export interface AddFoundationComponentOptions {
     template?: string;
     all?: boolean;
     useDefaults?: boolean;
+    list?: boolean;
 }
 
 export interface AddFoundationComponentOptionMessages {

--- a/packages/fast-cli/src/cli.ts
+++ b/packages/fast-cli/src/cli.ts
@@ -8,7 +8,7 @@ import { requiredComponentTemplateFiles } from "./components/files.js";
 import { componentExportFileNotFound, componentTemplateFileNotFoundMessage, componentTemplateFilesNotFoundMessage, fastConfigDoesNotContainComponentPathMessage, fastConfigDoesNotExistErrorMessage } from "./cli.errors.js";
 import type { WriteFileConfig } from "./cli.types.js";
 import type { ComponentTemplateConfig } from "./utilities/template.js";
-import { disallowedTemplateNames, suggestedTemplates } from "./components/options.js";
+import { availableTemplates, disallowedTemplateNames, suggestedTemplates } from "./components/options.js";
 import { copyFiles, createEmptyDir, localPathExists, readDir, readFile, writeFiles } from "./cli.fs.js";
 import { addComponentPrompts, addDesignSystemPrompts, addFoundationComponentPrompts, allowedFoundationComponentNamePrompt, configPrompts, initPrompts } from "./cli.prompt.js";
 import { __dirname, ascii, cliPath, defaultTemplatePath, folderMatches, templateFolderName } from "./cli.globals.js";
@@ -417,7 +417,9 @@ async function addFoundationComponent(
     options: AddFoundationComponentOptions,
     messages: AddFoundationComponentOptionMessages,
 ): Promise<void> {
-    if (options.all) {
+    if (options.list) {
+        availableTemplates.forEach((item) => console.log(item));
+    } else if (options.all) {
         for (const template of suggestedTemplates) {
             await addFoundationComponent(
                 {
@@ -613,7 +615,8 @@ program.command("add-component")
 
 const addFoundationComponentTemplateMessage = "The name of the foundation component template";
 const addFoundationComponentNameMessage = "The name of the component";
-const addFoundationComponentAllMessage = "Add all available foundation components"
+const addFoundationComponentAllMessage = "Add all available foundation components";
+const addFoundationComponentListMessage = "List available foundation components";
 
 program.command("add-foundation-component")
     .description("Add a foundation component")
@@ -621,7 +624,8 @@ program.command("add-foundation-component")
     .option("-n, --name <name>", addFoundationComponentNameMessage)
     .option("-a, --all", addFoundationComponentAllMessage)
     .option("-y, --yes-all", yesToAllDefaultsMessage)
-    .action(async (options): Promise<void> => {
+    .option("-l, --list", addFoundationComponentListMessage)
+    .action(async (options: AddFoundationComponentOptions): Promise<void> => {
         await addFoundationComponent(options, {
             template: addFoundationComponentTemplateMessage,
             name: addFoundationComponentNameMessage

--- a/packages/fast-cli/src/components/components.pw.spec.ts
+++ b/packages/fast-cli/src/components/components.pw.spec.ts
@@ -105,10 +105,6 @@ test.describe("CLI add-foundation-component", () => {
             ).not.toThrow();
         });
     });
-});
-
-
-test.describe("CLI add-foundation-component", () => {
     test.describe("--list", () => {
         test("should not throw", () => {
             expect(

--- a/packages/fast-cli/src/components/components.pw.spec.ts
+++ b/packages/fast-cli/src/components/components.pw.spec.ts
@@ -106,3 +106,16 @@ test.describe("CLI add-foundation-component", () => {
         });
     });
 });
+
+
+test.describe("CLI add-foundation-component", () => {
+    test.describe("--list", () => {
+        test("should not throw", () => {
+            expect(
+                () => {
+                    execSync(`cd ${tempDirComponentsAll} && npm run fast:add-foundation-component:list`);
+                }
+            ).not.toThrow();
+        });
+    });
+});

--- a/packages/fast-cli/src/test/helpers.ts
+++ b/packages/fast-cli/src/test/helpers.ts
@@ -27,6 +27,7 @@ function getPackageScripts(tempComponentDir: string): any {
         "fast:add-design-system:default": `fast add-design-system -y`,
         "fast:add-component:template": `fast add-component -n test-component -t ${tempComponentDir}`,
         "fast:add-foundation-component:all": `fast add-foundation-component -a`,
+        "fast:add-foundation-component:list": "fast add-foundation-component -l",
         ...availableTemplates.reduce((prevValue, currValue: string) => {
             return {
                 ...prevValue,

--- a/website/docs/add-a-foundation-component.md
+++ b/website/docs/add-a-foundation-component.md
@@ -15,3 +15,9 @@ Argument | Shorthand | Description | Required | Default
 `--template <template>` | `-t <template>` | The name of the foundation element | Yes | "accordion", "anchor", "anchored-region", "avatar", "badge", "blank", "breadcrumb", "button", "calendar", "card", "checkbox", "combobox", "data-grid", "dialog", "disclosure", "divider", "flipper", "horizontal-scroll", "listbox", "menu", "number-field", "picker", "progress", "progress-ring", "radio-group", "search", "select", "skeleton", "slider", "switch", "tabs", "text-area", "text-field", "toolbar", "tooltip", "tree-view" |
 `--name <name>` | `-n <name>` | The name of the component to be added | Yes | The name of the foundation template |
 `--all` | `-a` | Add all available components | No | 
+
+### Listing all components
+
+| Argument | Shorthand | Description | Required |
+|-|-|-|-|
+`--list` | `-l` | List all available components | No | 


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This change adds a `--list` option to the `add-foundation-components` command which will list all available foundation components.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.