### PR TITLE
Add a utility to read all file paths

### DIFF
--- a/change/@microsoft-fast-cli-f758f649-9d01-486b-b414-e3663dd42d70.json
+++ b/change/@microsoft-fast-cli-f758f649-9d01-486b-b414-e3663dd42d70.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add a utility to read all file paths",
+  "packageName": "@microsoft/fast-cli",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/fast-cli/src/cli.fs.spec.ts
+++ b/packages/fast-cli/src/cli.fs.spec.ts
@@ -5,6 +5,7 @@ import {
     getTempDir,
 } from "./test/helpers.js";
 import {
+    readAll,
     readFile,
     writeFiles
 } from "./cli.fs.js";
@@ -20,6 +21,10 @@ test.describe("fs", () => {
         fs.removeSync(tempDir)
     });
     test.describe("writeFiles", () => {
+        test.afterAll(() => {
+            fs.removeSync(path.resolve(tempDir, "baz1", "foo1.txt"));
+            fs.removeSync(path.resolve(tempDir, "baz2", "foo2.txt"));
+        });
         test("should write multiple files", () => {
             const name1 = "foo1.txt";
             const directory1 = path.resolve(tempDir, "baz1");
@@ -54,6 +59,10 @@ test.describe("fs", () => {
             fs.writeFileSync(path.resolve(tempDir, "read.txt"), "Hello world");
             fs.writeFileSync(path.resolve(tempDir, "read.json"), `{}`);
         });
+        test.afterAll(() => {
+            fs.removeSync(path.resolve(tempDir, "read.txt"));
+            fs.removeSync(path.resolve(tempDir, "read.json"));
+        });
         test("should read a JSON file", () => {
             const file = readFile(path.resolve(tempDir, "read.json"), true);
             expect(file).toEqual({});
@@ -62,5 +71,21 @@ test.describe("fs", () => {
             const file = readFile(path.resolve(tempDir, "read.txt"), false);
             expect(file).toEqual("Hello world");
         });
-    });    
+    });
+
+    test.describe("readAll", () => {
+        test.beforeAll(() => {
+            fs.writeFileSync(path.resolve(tempDir, "read.txt"), "Hello world");
+            fs.emptydirSync(path.resolve(tempDir, "foo"));
+            fs.writeFileSync(path.resolve(tempDir, "foo", "read.json"), `{}`);
+        });
+        test.afterAll(() => {
+            fs.removeSync(path.resolve(tempDir, "read.txt"));
+            fs.removeSync(path.resolve(tempDir, "foo", "read.json"));
+            fs.removeSync(path.resolve(tempDir, "foo"));
+        });
+        test("should get all file paths", () => {
+            expect(JSON.stringify(readAll(tempDir))).toEqual(JSON.stringify(["foo/read.json", "read.txt"]));
+        });
+    });
 });

--- a/packages/fast-cli/src/cli.fs.ts
+++ b/packages/fast-cli/src/cli.fs.ts
@@ -7,16 +7,16 @@ import type { WriteFileConfig } from "./cli.types.js";
  * This file includes utilities for file system updates
  */
 
-export function readFile<T>(path: string, json: boolean): T {
+export function readFile<T>(currentPath: string, json: boolean): T {
     if (json) {
-        return JSON.parse(fs.readFileSync(path, { encoding: "utf8" }));
+        return JSON.parse(fs.readFileSync(currentPath, { encoding: "utf8" }));
     }
     
-    return fs.readFileSync(path, { encoding: "utf8" });
+    return fs.readFileSync(currentPath, { encoding: "utf8" });
 }
 
-export function readDir(path: string): Array<string> {
-    return fs.readdirSync(path);
+export function readDir(currentPath: string): Array<string> {
+    return fs.readdirSync(currentPath);
 }
 
 export function copyFiles(fromDir: string, toDir: string): void {
@@ -43,10 +43,27 @@ export function writeFiles(files: Array<WriteFileConfig>): void {
     return;
 }
 
-export function createEmptyDir(path: string): void {
-    fs.emptydirSync(path);
+export function createEmptyDir(currentPath: string): void {
+    fs.emptydirSync(currentPath);
 }
 
-export async function localPathExists(path: string): Promise<boolean> {
-    return await fs.pathExists(path);
+export async function localPathExists(currentPath: string): Promise<boolean> {
+    return await fs.pathExists(currentPath);
+}
+
+export function readAll(currentPath: string, originalPath: string = currentPath): Array<string> {
+    const allFiles: Array<string> = [];
+    const status = fs.statSync(currentPath);
+
+    if (status.isDirectory()) {
+        readDir(currentPath).forEach((dirPath) => {
+            allFiles.push(
+                ...readAll(path.join(currentPath, dirPath), originalPath)
+            );
+        });
+    } else {
+        allFiles.push(path.relative(originalPath, currentPath));
+    }
+
+    return allFiles;
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This utility reads all file paths of all files in a directory.

### 🎫 Issues

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->
Continues work on #121 

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.
-->
This utility is necessary for the upcoming NodeJS utility to write all template files from a location as an exported TypeScript file that can then be used by the CLI. See #121 for details.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
- Add a NodeJS utility script to read a template and produce an executable export for the CLI to consume