### PR TITLE
Added a utility to write template files in a TypeScript file as a default export

### DIFF
--- a/change/@microsoft-fast-cli-a6db2f9c-8387-4228-94e7-faa5dc347ba6.json
+++ b/change/@microsoft-fast-cli-a6db2f9c-8387-4228-94e7-faa5dc347ba6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Added a utility to write template files in a TypeScript file as a default export",
+  "packageName": "@microsoft/fast-cli",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/fast-cli/src/cli.fs.ts
+++ b/packages/fast-cli/src/cli.fs.ts
@@ -67,3 +67,31 @@ export function readAll(currentPath: string, originalPath: string = currentPath)
 
     return allFiles;
 }
+
+export interface InitializeProjectTemplateConfig {
+    templateDirectory: string;
+    writeFilePath: string;
+}
+
+export function writeTemplateExportFile(
+    config: InitializeProjectTemplateConfig
+): void {
+    const templateFiles: Array<WriteFileConfig> = readAll(
+        config.templateDirectory
+    ).map((filePath: string): WriteFileConfig => {
+        const absolutePath = path.join(config.templateDirectory, filePath);
+        return {
+            directory: path.dirname(absolutePath),
+            name: path.basename(absolutePath),
+            contents: readFile(absolutePath, false)
+        };
+    });
+
+    writeFiles([
+        {
+            directory: path.dirname(config.writeFilePath),
+            name: path.basename(config.writeFilePath),
+            contents: `export default ${JSON.stringify(templateFiles, null, 2)}`
+        }
+    ]);
+}

--- a/packages/fast-cli/src/cli.ts
+++ b/packages/fast-cli/src/cli.ts
@@ -651,3 +651,4 @@ program.parse(process.argv);
 
 export { ComponentTemplateConfig };
 export { htmlTemplate, mdTemplate, tsTemplate } from "./cli.template.js";
+export { writeTemplateExportFile } from "./cli.fs.js";


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This change adds a utility file for use in the `@microsoft/cfp-template` which will take a dependency on the new private package introduced in #120 and use this utility to generate an exported script. This will eliminate pathing problems occurring from the current use of `fs` to read template files. Instead the contents of the files will be imported as they will be written to an exported script.

### 🎫 Issues

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->
Continues work on #121 

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
- Merge #120
- Delete `template/` folder from `@microsoft/cfp-template`
- Add `@microsoft/cfp-template-files` as a devDependency of `@microsoft/cfp-template`
- Add a NodeJs script to execute the utility added in this PR against the contents of `@microsoft/cfp-template-files`