### PR TITLE
Add minimatch for glob patterns and a list of excluded paths

### DIFF
--- a/change/@microsoft-fast-cli-bb6f8954-f5e8-4b31-aba5-ad37ae864900.json
+++ b/change/@microsoft-fast-cli-bb6f8954-f5e8-4b31-aba5-ad37ae864900.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added minimatch for glob patterns and allowed excluded paths from a template and a prepended string",
+  "packageName": "@microsoft/fast-cli",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "minor"
+}

--- a/change/@microsoft-fast-cli-da07c2b0-1c27-4498-bf5b-64e471205053.json
+++ b/change/@microsoft-fast-cli-da07c2b0-1c27-4498-bf5b-64e471205053.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Ensure template spec files are not ignored",
+  "comment": "Ensured template spec files are not ignored",
   "packageName": "@microsoft/fast-cli",
   "email": "7559015+janechu@users.noreply.github.com",
   "dependentChangeType": "prerelease"

--- a/change/@microsoft-fast-cli-f758f649-9d01-486b-b414-e3663dd42d70.json
+++ b/change/@microsoft-fast-cli-f758f649-9d01-486b-b414-e3663dd42d70.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Add a utility to read all file paths",
+  "comment": "Added a utility to read all file paths",
   "packageName": "@microsoft/fast-cli",
   "email": "7559015+janechu@users.noreply.github.com",
   "dependentChangeType": "prerelease"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9009,7 +9009,6 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/base": {
@@ -21812,11 +21811,20 @@
         "commander": "^9.0.0",
         "cross-spawn": "^7.0.3",
         "fs-extra": "^10.0.1",
+        "minimatch": "^5.1.0",
         "prompts": "^2.4.2",
         "tslib": "^2.4.0"
       },
       "bin": {
         "fast": "dist/esm/cli.js"
+      }
+    },
+    "packages/fast-cli/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "packages/fast-cli/node_modules/commander": {
@@ -21846,6 +21854,17 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "packages/fast-cli/node_modules/minimatch": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "packages/fast-cli/node_modules/prompts": {
@@ -23264,10 +23283,19 @@
         "commander": "^9.0.0",
         "cross-spawn": "^7.0.3",
         "fs-extra": "^10.0.1",
+        "minimatch": "^5.1.0",
         "prompts": "^2.4.2",
         "tslib": "^2.4.0"
       },
       "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
         "commander": {
           "version": "9.1.0"
         },
@@ -23284,6 +23312,14 @@
           "requires": {
             "graceful-fs": "^4.1.6",
             "universalify": "^2.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
           }
         },
         "prompts": {
@@ -28101,8 +28137,7 @@
       "dev": true
     },
     "balanced-match": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "base": {
       "version": "0.11.2",

--- a/packages/fast-cli/package.json
+++ b/packages/fast-cli/package.json
@@ -44,6 +44,7 @@
     "commander": "^9.0.0",
     "cross-spawn": "^7.0.3",
     "fs-extra": "^10.0.1",
+    "minimatch": "^5.1.0",
     "prompts": "^2.4.2",
     "tslib": "^2.4.0"
   }

--- a/packages/fast-cli/src/cli.fs.spec.ts
+++ b/packages/fast-cli/src/cli.fs.spec.ts
@@ -105,13 +105,40 @@ test.describe("fs", () => {
         test("should write an export file", async () => {
             writeTemplateExportFile({
                 templateDirectory: path.resolve(tempDir),
-                writeFilePath: path.resolve(tempDir, "export.ts")
+                writeFilePath: path.resolve(tempDir, "export1.ts")
             });
 
-            execSync(`tsc ${path.resolve(tempDir, "export.ts")}`);
-            const exportTemplate = await import(path.resolve(tempDir, "export.js"));
+            execSync(`tsc ${path.resolve(tempDir, "export1.ts")}`);
+            const exportTemplate = await import(path.resolve(tempDir, "export1.js"));
 
             expect(Array.isArray(exportTemplate.default.default)).toBeTruthy();
+        });
+        test("should write an export file and ignore excluded paths", async () => {
+            writeTemplateExportFile({
+                templateDirectory: path.resolve(tempDir),
+                writeFilePath: path.resolve(tempDir, "export2.ts"),
+                excludedPaths: [
+                    "**/foo/*.*",
+                    "**/export1.*"
+                ]
+            });
+
+            execSync(`tsc ${path.resolve(tempDir, "export2.ts")}`);
+            const exportTemplate = await import(path.resolve(tempDir, "export2.js"));
+
+            expect(exportTemplate.default.default).toHaveLength(1);
+        });
+        test("should prepend the excluded file with custom text", async () => {
+            const prependComment = "// hello";
+            writeTemplateExportFile({
+                templateDirectory: path.resolve(tempDir),
+                writeFilePath: path.resolve(tempDir, "export3.ts"),
+                prepend: prependComment
+            });
+
+            const fileContents: string = readFile(path.resolve(tempDir, "export3.ts"), false);
+
+            expect(fileContents.startsWith(prependComment)).toBeTruthy();
         });
     });
 });


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This change adds the `minimatch` dependency, used in globbing to allow a list of excluded paths to the template logic.

It also adds a prepend string option so that users can generate a file and include comments.

### 🎫 Issues

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->
Continues work on #121

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
- See #121