### PR TITLE
Update method of generating template exports to allow more flexibility and multiple exports

### DIFF
--- a/change/@microsoft-cfp-template-ac740952-967e-4177-a28b-2d44c298c1f4.json
+++ b/change/@microsoft-cfp-template-ac740952-967e-4177-a28b-2d44c298c1f4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Updated method of generating exports to allow more flexibility and multiple exports",
+  "packageName": "@microsoft/cfp-template",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "prerelease"
+}

--- a/change/@microsoft-fast-cli-6a58ba9a-5e3a-402c-956b-e9f0753a0f93.json
+++ b/change/@microsoft-fast-cli-6a58ba9a-5e3a-402c-956b-e9f0753a0f93.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Updated method of generating exports to allow more flexibility and multiple exports",
+  "packageName": "@microsoft/fast-cli",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/cfp-template/build/generate.js
+++ b/packages/cfp-template/build/generate.js
@@ -1,4 +1,4 @@
-import { writeTemplateExportFile } from "@microsoft/fast-cli/fs";
+import { getTemplateFileConfig, writeFiles } from "@microsoft/fast-cli/fs";
 import path from "path";
 
 /**
@@ -9,18 +9,30 @@ import path from "path";
 const templateDirectory = path.resolve("../", "cfp-template-files");
 const writeFilePath = path.resolve("./src/index.ts");
 
-writeTemplateExportFile({
-    templateDirectory,
-    writeFilePath,
-    excludedPaths: [
-        "**/node_modules/**",
-        "**/www/**",
-        "**/dist/**"
-    ],
-    prepend:
+(function(){
+    const prepend =
 `/**
  * This file has been automatically generated from the ./build/generate.js scripts,
  * do not attempt to edit it. To re-generate the file run: npm run generate
- */
-`
-});
+ */`
+    const templateFiles = getTemplateFileConfig({
+        templateDirectory,
+        excludedPaths: [
+            "**/node_modules/**",
+            "**/www/**",
+            "**/dist/**"
+        ],
+    })
+
+    writeFiles([
+        {
+            directory: path.dirname(writeFilePath),
+            name: path.basename(writeFilePath),
+            contents:
+`${prepend || ""}
+const cfpAppTemplate = ${JSON.stringify(templateFiles, null, 2)}
+export { cfpAppTemplate };`
+        }
+    ]);
+
+}());

--- a/packages/cfp-template/src/index.ts
+++ b/packages/cfp-template/src/index.ts
@@ -2,7 +2,7 @@
  * This file has been automatically generated from the ./build/generate.js scripts,
  * do not attempt to edit it. To re-generate the file run: npm run generate
  */
-export default [
+const cfpAppTemplate = [
   {
     "directory": ".",
     "name": ".eslintignore",
@@ -134,3 +134,4 @@ export default [
     "contents": "/* eslint-disable @typescript-eslint/no-var-requires */\n/* eslint-disable no-undef */\nconst merge = require(\"webpack-merge\");\nconst baseConfig = require(\"./webpack.common.cjs\");\n\nmodule.exports = merge(baseConfig, {\n    mode: \"production\",\n    optimization: {\n        splitChunks: {\n            chunks: \"all\",\n            maxInitialRequests: 100,\n            cacheGroups: {\n                vendor: {\n                    test: /[\\\\/]node_modules[\\\\/]/,\n                    name: module => {\n                        const packageName = module.context.match(\n                            /[\\\\/]node_modules[\\\\/](.*?)([\\\\/]|$)/\n                        )[1];\n                        // npm package names are URL-safe, but some servers don't like @ symbols\n                        return `npm.${packageName.replace(\"@\", \"\")}`;\n                    },\n                },\n            },\n        },\n    },\n    output: {\n        filename: \"bundle/[name].[contenthash].js\",\n    },\n});\n"
   }
 ]
+export { cfpAppTemplate };

--- a/packages/fast-cli/src/cli.fs.spec.ts
+++ b/packages/fast-cli/src/cli.fs.spec.ts
@@ -8,7 +8,7 @@ import {
     readAll,
     readFile,
     writeFiles,
-    writeTemplateExportFile
+    getTemplateFileConfig
 } from "./cli.fs.js";
 import { execSync } from "child_process";
 
@@ -91,7 +91,7 @@ test.describe("fs", () => {
         });
     });
 
-    test.describe("writeTemplateExportFile", () => {
+    test.describe("getTemplateFileConfig", () => {
         test.beforeAll(() => {
             fs.writeFileSync(path.resolve(tempDir, "read.txt"), "Hello world");
             fs.emptydirSync(path.resolve(tempDir, "foo"));
@@ -102,43 +102,24 @@ test.describe("fs", () => {
             fs.removeSync(path.resolve(tempDir, "foo", "read.json"));
             fs.removeSync(path.resolve(tempDir, "foo"));
         });
-        test("should write an export file", async () => {
-            writeTemplateExportFile({
+        test("should get an project template config array", async () => {
+            const templateFileConfig = getTemplateFileConfig({
                 templateDirectory: path.resolve(tempDir),
-                writeFilePath: path.resolve(tempDir, "export1.ts")
             });
 
-            execSync(`tsc ${path.resolve(tempDir, "export1.ts")}`);
-            const exportTemplate = await import(path.resolve(tempDir, "export1.js"));
-
-            expect(Array.isArray(exportTemplate.default.default)).toBeTruthy();
+            expect(Array.isArray(templateFileConfig)).toBeTruthy();
+            expect(templateFileConfig).toHaveLength(2);
         });
-        test("should write an export file and ignore excluded paths", async () => {
-            writeTemplateExportFile({
+        test("should get an project template config array and ignore excluded paths", async () => {
+            const templateFileConfig = getTemplateFileConfig({
                 templateDirectory: path.resolve(tempDir),
-                writeFilePath: path.resolve(tempDir, "export2.ts"),
                 excludedPaths: [
                     "**/foo/*.*",
                     "**/export1.*"
                 ]
             });
 
-            execSync(`tsc ${path.resolve(tempDir, "export2.ts")}`);
-            const exportTemplate = await import(path.resolve(tempDir, "export2.js"));
-
-            expect(exportTemplate.default.default).toHaveLength(1);
-        });
-        test("should prepend the excluded file with custom text", async () => {
-            const prependComment = "// hello";
-            writeTemplateExportFile({
-                templateDirectory: path.resolve(tempDir),
-                writeFilePath: path.resolve(tempDir, "export3.ts"),
-                prepend: prependComment
-            });
-
-            const fileContents: string = readFile(path.resolve(tempDir, "export3.ts"), false);
-
-            expect(fileContents.startsWith(prependComment)).toBeTruthy();
+            expect(templateFileConfig).toHaveLength(1);
         });
     });
 });

--- a/packages/fast-cli/src/cli.fs.ts
+++ b/packages/fast-cli/src/cli.fs.ts
@@ -71,9 +71,7 @@ export function readAll(currentPath: string, originalPath: string = currentPath)
 
 export interface InitializeProjectTemplateConfig {
     templateDirectory: string;
-    writeFilePath: string;
     excludedPaths?: string[];
-    prepend?: string;
 }
 
 function containsExcludedPath(filePath: string, excludedPaths: string[]): boolean {
@@ -88,10 +86,10 @@ function containsExcludedPath(filePath: string, excludedPaths: string[]): boolea
     return contained;
 }
 
-export function writeTemplateExportFile(
+export function getTemplateFileConfig(
     config: InitializeProjectTemplateConfig
-): void {
-    const templateFiles: Array<WriteFileConfig> = readAll(
+): Array<WriteFileConfig> {
+    return readAll(
         config.templateDirectory
     ).map((filePath: string): WriteFileConfig | void => {
         if (!containsExcludedPath(filePath, config.excludedPaths || [])) {
@@ -105,12 +103,4 @@ export function writeTemplateExportFile(
     }).filter((item: WriteFileConfig | void): boolean => {
         return typeof item !== "undefined";
     }) as Array<WriteFileConfig>;
-
-    writeFiles([
-        {
-            directory: path.dirname(config.writeFilePath),
-            name: path.basename(config.writeFilePath),
-            contents: `${config.prepend || ""}export default ${JSON.stringify(templateFiles, null, 2)}`
-        }
-    ]);
 }

--- a/packages/fast-cli/src/cli.globals.ts
+++ b/packages/fast-cli/src/cli.globals.ts
@@ -1,7 +1,9 @@
 import path from "path";
 
 export const __dirname = path.resolve(path.dirname(""));
-export const defaultTemplatePath = path.join("@microsoft", "cfp-template");
+export const initDefaultTemplate = path.join("@microsoft", "cfp-template");
+export const initDefaultFilePath = path.join("dist", "esm", "index.js");
+export const initDefaultExportName = "cfpAppTemplate";
 export const cliPath = path.resolve(__dirname, "node_modules", "@microsoft", "fast-cli");
 export const templateFolderName = "template";
 /* eslint-disable no-useless-escape */

--- a/packages/fast-cli/src/cli.options.ts
+++ b/packages/fast-cli/src/cli.options.ts
@@ -54,6 +54,7 @@ export interface FastAddComponent {
 export interface FastInitOptionMessages {
     template: string;
     filePath: string;
+    exportName: string;
 }
 
 export interface AddDesignSystemOptions {
@@ -131,6 +132,11 @@ export interface InitOptions {
      * Path to export containing template
      */
     filePath: string;
+
+    /**
+     * If this is a named export, provide the name
+     */
+    exportName: string;
 }
 
 export interface TemplateFileConfig {

--- a/packages/fast-cli/src/cli.prompt.ts
+++ b/packages/fast-cli/src/cli.prompt.ts
@@ -184,12 +184,7 @@ export async function initPrompts(
 
     if (options.useDefaults) {
         config = { ...defaults, ...options };
-    }
-
-    if (!config.template) {
-        /**
-         * Collect information for the package.json file
-         */
+    } else if (!config.template) {
          config.template = await prompts([
             {
                 type: "text",
@@ -204,7 +199,7 @@ export async function initPrompts(
                 {
                     type: "text",
                     name: "filePath",
-                    initial: defaults.filePath,
+                    initial: "default",
                     message: messages.filePath,
                 }
             ]).filePath;

--- a/packages/fast-cli/src/cli.ts
+++ b/packages/fast-cli/src/cli.ts
@@ -426,7 +426,7 @@ async function init(
     await installTemplate(config.template);
     
     const exports = await import(path.join(config.template, config.filePath));
-    writeFiles(exports[config.exportName || "default"]);
+    writeFiles(exports[config.exportName]);
     await installDependencies([]);
 
     const templatePackageJson: any = readFile(path.resolve(".", "package.json"), true);

--- a/packages/fast-cli/src/cli.ts
+++ b/packages/fast-cli/src/cli.ts
@@ -10,7 +10,7 @@ import type { WriteFileConfig } from "./cli.types.js";
 import { availableTemplates, disallowedTemplateNames, suggestedTemplates } from "./components/options.js";
 import { createEmptyDir, localPathExists, readDir, readFile, writeFiles } from "./cli.fs.js";
 import { addComponentPrompts, addDesignSystemPrompts, addFoundationComponentPrompts, allowedFoundationComponentNamePrompt, configPrompts, initPrompts } from "./cli.prompt.js";
-import { __dirname, ascii, cliPath, templateFolderName, initDefaultFilePath, initDefaultExportName, initDefaultTemplate } from "./cli.globals.js";
+import { __dirname, ascii, cliPath, initDefaultExportName, initDefaultFilePath, initDefaultTemplate, templateFolderName } from "./cli.globals.js";
 import { stringModifier, toCamelCase, toPascalCase } from "./cli.utilities.js";
 import designSystemTemplate from "./templates/design-system.js";
 

--- a/packages/fast-cli/src/cli.ts
+++ b/packages/fast-cli/src/cli.ts
@@ -10,7 +10,7 @@ import type { WriteFileConfig } from "./cli.types.js";
 import { availableTemplates, disallowedTemplateNames, suggestedTemplates } from "./components/options.js";
 import { createEmptyDir, localPathExists, readDir, readFile, writeFiles } from "./cli.fs.js";
 import { addComponentPrompts, addDesignSystemPrompts, addFoundationComponentPrompts, allowedFoundationComponentNamePrompt, configPrompts, initPrompts } from "./cli.prompt.js";
-import { __dirname, ascii, cliPath, defaultTemplatePath, templateFolderName } from "./cli.globals.js";
+import { __dirname, ascii, cliPath, templateFolderName, initDefaultFilePath, initDefaultExportName, initDefaultTemplate } from "./cli.globals.js";
 import { stringModifier, toCamelCase, toPascalCase } from "./cli.utilities.js";
 import designSystemTemplate from "./templates/design-system.js";
 
@@ -425,10 +425,8 @@ async function init(
 
     await installTemplate(config.template);
     
-    const {
-        default: exports,
-    } = await import(path.join(config.template, config.filePath));
-    writeFiles(exports);
+    const exports = await import(path.join(config.template, config.filePath));
+    writeFiles(exports[config.exportName || "default"]);
     await installDependencies([]);
 
     const templatePackageJson: any = readFile(path.resolve(".", "package.json"), true);
@@ -446,9 +444,11 @@ const yesToAllDefaultsMessage: string = "Use all defaults";
 
 const initTemplateMessage: string = "Project template";
 const initFilePathMessage: string = "Export file path";
+const initExportNameMessage: string = "Export name";
 const initDefaults: Partial<InitOptions> = {
-    template: defaultTemplatePath,
-    filePath: path.join("dist", "esm", "index.js"),
+    template: initDefaultTemplate,
+    filePath: initDefaultFilePath,
+    exportName: initDefaultExportName
 }
 
 program
@@ -456,6 +456,7 @@ program
     .description("Initialize a new project")
     .option("-t, --template <template>", initTemplateMessage, initDefaults.template)
     .option("-f, --file-path <file-path>", initFilePathMessage, initDefaults.filePath)
+    .option("-n, --export-name <export-name>", initExportNameMessage, initDefaults.exportName)
     .option("-y, --yes-all", yesToAllDefaultsMessage)
     .action(async (options): Promise<void> => {
         await init(
@@ -463,6 +464,7 @@ program
             {
                 template: initTemplateMessage,
                 filePath: initFilePathMessage,
+                exportName: initExportNameMessage,
             },
             initDefaults
         ).catch((reason) => {

--- a/website/docs/initialize.md
+++ b/website/docs/initialize.md
@@ -34,3 +34,4 @@ Argument | Shorthand | Description | Required | Default
 ---------|-----------|-------------|----------|--------
 `--template <path/to/template-package>` | `-t <path/to/template-package>` | Use template package | No | "@microsoft/cfp-template"
 `--filePath <path/to/file>` | `-f <path/to/file>` | Path to the file | No | "dist/esm/index.js"
+`--exportName <export-name>` | `-n <export-name>` | Name of the export | No | "default"


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This change:
- Updates the exported function to instead return an array of files that can be used with the `writeFile` utility
- Updates the generated export from the `@microsoft/cfp-template` to be named `cfpAppTemplate` so that future exports can be added, such as `cfpDesignSystemTemplate` and `cfpComponentLibraryTemplate`.

### 🎫 Issues

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->
- Continues work on #121

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
