### PR TITLE
Updated workflows to trigger documentation site update after publish or manually

### DIFF
--- a/.github/workflows/cd-gh-pages.yml
+++ b/.github/workflows/cd-gh-pages.yml
@@ -2,9 +2,9 @@ name: Deploy GitHub Pages
 
 on:
   workflow_dispatch:
-  push:
-    branches: 
-      - main
+  workflow_run:
+    workflows: [Release Packages]
+    types: [completed]
 
 jobs:
   build:


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
The previous dispatch of the documentation site was after ever merge to `main` branch. This causes a difference between work in progress merged to `main` and what is actually published. Therefore, the documentation site can now be automatically published after a publish event, or manually triggered.

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.
-->
Note that the current documentation site is out of sync due to the issue outlined above, and until the prerelease phase is over this will only be manually triggered due to constraints with pre-releasing using Beachball. 

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.